### PR TITLE
fix(tenants): use nameEn for English locale on platform admin list

### DIFF
--- a/src/components/saas-dashboard/tenants/content.tsx
+++ b/src/components/saas-dashboard/tenants/content.tsx
@@ -60,6 +60,7 @@ async function getTenants(searchParams: Props["searchParams"], lang: Locale) {
       select: {
         id: true,
         name: true,
+        nameEn: true,
         domain: true,
         isActive: true,
         planType: true,
@@ -81,15 +82,21 @@ async function getTenants(searchParams: Props["searchParams"], lang: Locale) {
     db.school.count({ where }),
   ])
 
+  // Prefer pre-translated nameEn for English locale to skip the translation API
+  // (canonical pattern from (school-dashboard)/layout.tsx:67-76).
+  // Fall back to on-demand translation only when nameEn is not set.
   const translatedNames = await Promise.all(
-    tenants.map((tenant) =>
-      getDisplayText(
+    tenants.map((tenant) => {
+      if (lang === "en" && tenant.nameEn) {
+        return Promise.resolve(tenant.nameEn)
+      }
+      return getDisplayText(
         tenant.name,
         (tenant.preferredLanguage ?? "ar") as "en" | "ar",
         lang,
         tenant.id
       )
-    )
+    })
   )
 
   const rows: TenantRow[] = tenants.map((tenant, i) => ({


### PR DESCRIPTION
## Summary
- The `/en/tenants` page rendered the Arabic school name even when `lang=en`. The saas-dashboard tenants list went straight to `getDisplayText` without checking `school.nameEn` first, and when the Google Translate fallback failed silently, `getDisplayText` returned the source Arabic.
- Mirror the canonical pattern from `src/app/[lang]/s/[subdomain]/(school-dashboard)/layout.tsx:67-76`: prefer pre-translated `school.nameEn` for English locale, fall through to on-demand translation only when `nameEn` is unset.
- Bonus: removes a per-render translation API call for English viewers of already-translated school names (cost reduction).

## Changes
- `src/components/saas-dashboard/tenants/content.tsx`: add `nameEn: true` to the Prisma `select`; prefer `nameEn` for English locale before calling `getDisplayText`.

## Test plan
- [ ] On staging, visit `/en/tenants` as DEVELOPER → "King Fahad" (or equivalent `nameEn`) renders for tenants that have `nameEn` set.
- [ ] On `/ar/tenants`, the Arabic `name` still renders (no regression).
- [ ] For tenants without `nameEn` set, the existing `getDisplayText` translation path still runs.

Closes #261