### PR TITLE
feat(report): upgrade action to scoring pipeline + captcha hardening

### DIFF
--- a/src/lib/actions/report-issue.ts
+++ b/src/lib/actions/report-issue.ts
@@ -3,108 +3,60 @@
 "use server"
 
 /**
- * Report-issue server action — bare-fetch shim during Phase 1a rollout.
+ * Report-issue server action — thin wrapper around the shared pipeline.
  *
- * The new scoring pipeline lives at /Users/abdout/hogwarts/src/lib/report/
- * and is fully wired in the canonical client at
- * /Users/abdout/hogwarts/src/components/report-issue/dialog.tsx, but production
- * env vars (ANTHROPIC_API_KEY, TURNSTILE_*, REPORT_IP_SALT) aren't configured
- * yet. Until they are, this action keeps the original bare-GitHub-POST behavior
- * so the dialog stays functional.
- *
- * The follow-up PR replaces this body with:
- *
- *     const { runReportPipeline } = await import("@/lib/report");
- *     const { hogwartsReportAdapter } = await import("@/lib/report/adapter");
- *     return runReportPipeline(data, hogwartsReportAdapter, { ip });
- *
- * Once Vercel env is configured. The signature already matches the new client.
+ * All quality gating (Zod, hard filters, captcha, dedup, AI triage, scoring)
+ * lives in runReportPipeline. The client receives a symmetric success shape so
+ * spammers can't probe the filter. Replaces the Phase-1a bare-GitHub-POST shim
+ * now that prod env (ANTHROPIC_API_KEY) is configured and captcha degrades
+ * gracefully when Turnstile is absent.
  */
-import { auth } from "@/auth"
+import { headers } from "next/headers"
 
+import { runReportPipeline } from "@/lib/report"
+import { hogwartsReportAdapter } from "@/lib/report/adapter"
 import type {
   ReportIssueSubmitInput,
   ReportIssueSubmitResult,
 } from "@/components/report-issue/dialog"
 
+async function clientIp(): Promise<string> {
+  try {
+    const h = await headers()
+    const fwd = h.get("x-forwarded-for")
+    if (fwd) return fwd.split(",")[0]!.trim()
+    return h.get("x-real-ip") || "0.0.0.0"
+  } catch {
+    return "0.0.0.0"
+  }
+}
+
 export async function reportIssue(
   data: ReportIssueSubmitInput
 ): Promise<ReportIssueSubmitResult> {
-  const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN
-  const repo = process.env.GITHUB_REPO || "databayt/hogwarts"
-
-  if (!token) {
-    console.error("[report-issue] GITHUB_PERSONAL_ACCESS_TOKEN not configured")
-    return { ok: false }
-  }
-
-  // Category prefix in title: [visual] page layout
-  const prefix =
-    data.category && data.category !== "other" ? `[${data.category}] ` : ""
-  const desc = data.description
-  const maxLen = 80 - prefix.length
-  const truncated =
-    desc.length > maxLen ? desc.slice(0, maxLen - 3) + "..." : desc
-  const title = prefix + truncated
-
-  // Reporter from auth session — minimum signal the legacy action lost.
-  const session = await auth().catch(() => null)
-  const sessionUser = session?.user as
-    | { name?: string | null; email?: string | null }
-    | undefined
-  const reporter = sessionUser
-    ? `${sessionUser.name ?? "(no name)"} (${sessionUser.email ?? "no email"})`
-    : "Anonymous"
-
-  const body = [
-    data.description,
-    "",
-    "---",
-    "",
-    `**Page**: ${data.pageUrl}`,
-    `**Reporter**: ${reporter}`,
-    `**Time**: ${new Date().toISOString()}`,
-    data.category ? `**Category**: ${data.category}` : "",
-    data.viewport ? `**Viewport**: ${data.viewport}` : "",
-    data.direction ? `**Direction**: ${data.direction}` : "",
-    data.browser ? `**Browser**: ${data.browser}` : "",
-  ]
-    .filter((line) => line !== "")
-    .join("\n")
-
-  const response = await fetch(`https://api.github.com/repos/${repo}/issues`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
+  const ip = await clientIp()
+  const result = await runReportPipeline(
+    {
+      description: data.description,
+      pageUrl: data.pageUrl,
+      category: data.category,
+      reproSteps: data.reproSteps,
+      expected: data.expected,
+      actual: data.actual,
+      severityHint: data.severityHint,
+      viewport: data.viewport,
+      direction: data.direction,
+      browser: data.browser,
+      hasScreenshot: data.hasScreenshot,
+      captchaToken: data.captchaToken,
     },
-    body: JSON.stringify({ title, body, labels: ["report"] }),
-  })
+    hogwartsReportAdapter,
+    { ip }
+  )
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => "")
-    console.error(`[report-issue] GitHub API ${response.status}: ${text}`)
-    return { ok: false }
+  if (result.ok && result.bucket === "verified-report" && result.issueNumber) {
+    return { ok: true, issueNumber: result.issueNumber }
   }
-
-  // Acknowledgment comment (fire-and-forget)
-  const issueData = (await response.json().catch(() => null)) as {
-    number?: number
-    comments_url?: string
-  } | null
-  const issueNumber = issueData?.number
-  if (issueData?.comments_url) {
-    fetch(issueData.comments_url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-      },
-      body: JSON.stringify({
-        body: "Received. This report is queued for automated review and fix. You'll be notified here when resolved.",
-      }),
-    }).catch(() => {})
-  }
-
-  return issueNumber ? { ok: true, issueNumber } : { ok: true }
+  if (result.ok) return { ok: true }
+  return { ok: false }
 }

--- a/src/lib/report/hard-filters.ts
+++ b/src/lib/report/hard-filters.ts
@@ -74,12 +74,14 @@ export function runHardFilters(
     }
   }
 
-  // HF3 — anonymous needs valid captcha. (When ctx.captchaValid is null, captcha
-  // wasn't required — e.g. authenticated user on a non-anon page.)
-  if (reporter.kind === "anonymous" && ctx.captchaValid !== true) {
+  // HF3 — reject only when captcha was CONFIGURED-but-failed (explicit false).
+  // When captchaValid is null (Turnstile not enforced: authenticated user, or a
+  // deployment with no Turnstile keys) the report proceeds at degraded trust —
+  // a missing env var must never silently eat a legit report.
+  if (reporter.kind === "anonymous" && ctx.captchaValid === false) {
     return {
       code: "HF3_no_captcha",
-      detail: "Anonymous reports require a valid Turnstile token.",
+      detail: "Anonymous report failed Turnstile verification.",
     }
   }
 

--- a/src/lib/report/pipeline.ts
+++ b/src/lib/report/pipeline.ts
@@ -23,7 +23,7 @@ import { hostMatches, runHardFilters } from "./hard-filters"
 import { reportSchema, type ReportInputParsed } from "./schema"
 import { computeScore } from "./score"
 import { classifyWithHaiku } from "./triage"
-import { verifyTurnstile } from "./turnstile"
+import { isTurnstileConfigured, verifyTurnstile } from "./turnstile"
 import type {
   AITriageResult,
   PipelineEvent,
@@ -88,9 +88,11 @@ export async function runReportPipeline(
     throw err
   }
 
-  // 4. Captcha — required for anonymous, optional otherwise
+  // 4. Captcha — enforced for anonymous ONLY when Turnstile is configured.
+  // Unconfigured → captchaValid stays null (HF3 won't reject) so reports still
+  // land (degraded trust). This stops a missing env var silently eating reports.
   let captchaValid: boolean | null = null
-  if (reporter.kind === "anonymous") {
+  if (reporter.kind === "anonymous" && isTurnstileConfigured()) {
     captchaValid = await verifyTurnstile(input.captchaToken, opts.ip)
   }
 

--- a/src/lib/report/turnstile.ts
+++ b/src/lib/report/turnstile.ts
@@ -12,14 +12,23 @@
 
 const VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 
+/**
+ * Is Turnstile configured for this deployment? When false, captcha is NOT
+ * enforced — the pipeline leaves captchaValid=null so anonymous reports still
+ * go through (degraded trust, lower score) instead of silently vanishing.
+ */
+export function isTurnstileConfigured(): boolean {
+  return Boolean(process.env.TURNSTILE_SECRET_KEY)
+}
+
 export async function verifyTurnstile(
   token: string | undefined,
   ip: string
 ): Promise<boolean> {
   const secret = process.env.TURNSTILE_SECRET_KEY
   if (!secret) {
-    // In development without a Turnstile secret, pass through. Real deployments
-    // must set the env var (otherwise HF3 would reject every anonymous report).
+    // Unconfigured: callers should gate on isTurnstileConfigured() and not
+    // enforce captcha at all. If we still get here, pass in dev, fail in prod.
     if (process.env.NODE_ENV !== "production") return true
     console.warn("[turnstile] TURNSTILE_SECRET_KEY not set in production")
     return false


### PR DESCRIPTION
Replaces the Phase-1a bare-GitHub-POST shim with `runReportPipeline` + `hogwartsReportAdapter` (the upgrade the shim's comment documented as pending). hogwarts reports now get hard filters, AI triage, scoring/bucketing, dedup, corroboration — same pipeline as kun.

Includes the **captcha graceful-degradation hardening** (matches databayt/kun#85 + the codebase canonical): unconfigured Turnstile → anonymous reports proceed at degraded trust instead of silent-rejecting. Paired with `ANTHROPIC_API_KEY` now set in hogwarts prod.

**Verification:** report module typechecks clean; 29/30 report tests pass — the 1 failure (HF6/HF7 gibberish ordering) is pre-existing (fails identically on main, unrelated).