### PR TITLE
fix(onboarding): scale price font for long values to keep mobile fit

### DIFF
--- a/src/components/onboarding/price/content.tsx
+++ b/src/components/onboarding/price/content.tsx
@@ -142,6 +142,16 @@ export default function PriceContent({ dictionary, lang, id }: Props) {
 
   const displayValue = `${currencySymbol}${price}`
 
+  // The inline style.width below grows linearly with content length, so the
+  // font has to shrink for long values or the input overflows narrow phones
+  // (e.g. "$500000" at text-6xl ≈ 336px exceeds a 320px viewport).
+  const fontSizeClass =
+    displayValue.length <= 5
+      ? "text-4xl sm:text-5xl md:text-6xl"
+      : displayValue.length <= 7
+        ? "text-3xl sm:text-4xl md:text-5xl"
+        : "text-2xl sm:text-3xl md:text-4xl"
+
   return (
     <div className="flex flex-col items-center space-y-6">
       {errorText && (
@@ -181,7 +191,7 @@ export default function PriceContent({ dictionary, lang, id }: Props) {
                 )
               }
             }}
-            className="text-foreground w-auto max-w-full min-w-0 border-none bg-transparent text-center text-4xl font-extrabold outline-none sm:text-5xl md:text-6xl"
+            className={`text-foreground w-auto max-w-full min-w-0 border-none bg-transparent text-center font-extrabold outline-none ${fontSizeClass}`}
             style={{
               width: `${displayValue.length * 0.8}em`,
               caretColor: "var(--foreground)",


### PR DESCRIPTION
## Summary

On the `/onboarding/.../price` step, the price input width is set via inline `style.width: ${displayValue.length * 0.8}em`. At `text-6xl` (3.75rem ≈ 60px), a value like `$500000` (7 chars) computes to ~336px — wider than a 320px iPhone-SE viewport. The footer's fixed `Next` button is then cut off and the input itself horizontally scrolls.

Issue #306 reports the symptom in Arabic: "عند تعديل الرقم برقم كبير، 500000 مثلاً الريسبونسف بتخرب".

## Fix

Pick a smaller text-size class as `displayValue` grows past 5 and 7 characters. The dynamic em-based width still grows, but each em is now smaller (text-3xl = 1.875rem) so the total stays inside the viewport.

| `displayValue` | Old (always) | New |
|---|---|---|
| ≤ 5 chars (`$5000`) | text-4xl / 5xl / 6xl | text-4xl / 5xl / 6xl (unchanged) |
| 6–7 chars (`$500000`) | text-4xl / 5xl / 6xl | text-3xl / 4xl / 5xl |
| 8+ chars (`$5000000`) | text-4xl / 5xl / 6xl | text-2xl / 3xl / 4xl |

## Changes

- `src/components/onboarding/price/content.tsx`: compute `fontSizeClass` from `displayValue.length`; apply it to the input className. Brief comment explains why the dynamic style.width forces the font to scale.

## Test plan

- [ ] On staging, visit `/ar/onboarding/<id>/price` on a mobile viewport (≤375px).
- [ ] Type `500000` — input fits, footer Next button is fully visible.
- [ ] Type `50000000` — input still fits at the smallest font tier.
- [ ] Default value `5000` renders at the original text-6xl size (no visual regression for normal prices).
- [ ] RTL (`/ar/...`) and LTR (`/en/...`) both behave.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)