### PR TITLE
fix(onboarding): use field-sizing for price input to stop responsive overflow

### DIFF
--- a/src/components/onboarding/price/content.tsx
+++ b/src/components/onboarding/price/content.tsx
@@ -181,11 +181,8 @@ export default function PriceContent({ dictionary, lang, id }: Props) {
                 )
               }
             }}
-            className="text-foreground w-auto max-w-full min-w-0 border-none bg-transparent text-center text-4xl font-extrabold outline-none sm:text-5xl md:text-6xl"
-            style={{
-              width: `${displayValue.length * 0.8}em`,
-              caretColor: "var(--foreground)",
-            }}
+            className="text-foreground field-sizing-content max-w-full min-w-0 border-none bg-transparent text-center text-4xl font-extrabold outline-none sm:text-5xl md:text-6xl"
+            style={{ caretColor: "var(--foreground)" }}
           />
           {!isFocused && (
             <div


### PR DESCRIPTION
## Summary
- Replace magic `${displayValue.length * 0.8}em` width calculation with native CSS `field-sizing-content`
- Auto-sizes the price input precisely to its rendered text — accurate for any font, weight, or locale (incl. Arabic digits)
- Same pattern already used in `textarea.tsx` and `prompt-input.tsx`

## Root cause
At `text-6xl` (60px) with a 6-digit value plus currency prefix (e.g. `USD500000`), the per-character `0.8em` multiplier overshoots actual extrabold digit width by ~30%, pushing the input to ~430px. That overflows the `flex-1` column inside `HostStepLayout`, breaking the responsive layout — the Edit button gets pushed off, surrounding content area starts to scroll horizontally.

## Changes
- `src/components/onboarding/price/content.tsx`: swap inline JS width math for the `field-sizing-content` Tailwind utility

## Test plan
- [ ] Visit `/ar/onboarding/<schoolId>/price`
- [ ] Type `500000` — layout stays intact, Edit button stays adjacent to the value
- [ ] Type `5000000` (7 digits) — input still grows naturally, no horizontal scroll
- [ ] Resize down to 375px mobile — input remains centered and within viewport
- [ ] Switch to `/en/...` locale — same behavior with USD symbol
- [ ] Reload and confirm initial value `5000` renders centered as before

Closes #306

Generated with [Claude Code](https://claude.com/claude-code)