### PR TITLE
feat(finance): wire postWalletTopup to the ledger

### DIFF
--- a/src/components/school-dashboard/finance/wallet/__tests__/actions.test.ts
+++ b/src/components/school-dashboard/finance/wallet/__tests__/actions.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "@/lib/db"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    wallet: { update: vi.fn() },
+    walletTransaction: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+// Hoist a mutable holder so each test can swap the postWalletTopup behavior
+// without re-importing the action under test.
+const ledgerMock = vi.hoisted(() => ({
+  postWalletTopup: vi.fn(),
+}))
+
+vi.mock("../../lib/accounting/actions", () => ledgerMock)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SCHOOL_ID = "test-school-id" // matches global auth mock in src/test/setup.ts
+const WALLET_ID = "wal-1"
+const TRANSACTION_ID = "txn-1"
+const TOPUP_DATE = new Date("2026-05-25T10:00:00Z")
+
+function buildFormData(overrides: Partial<Record<string, string>> = {}): FormData {
+  const fd = new FormData()
+  fd.set("walletId", overrides.walletId ?? WALLET_ID)
+  fd.set("amount", overrides.amount ?? "150")
+  fd.set("paymentMethod", overrides.paymentMethod ?? "CASH")
+  if (overrides.description !== undefined) fd.set("description", overrides.description)
+  return fd
+}
+
+function stubSuccessfulTransaction() {
+  const wallet = { id: WALLET_ID, balance: 250, schoolId: SCHOOL_ID }
+  const transaction = {
+    id: TRANSACTION_ID,
+    walletId: WALLET_ID,
+    amount: 150,
+    createdAt: TOPUP_DATE,
+  }
+  vi.mocked(db.$transaction).mockImplementation(async (cb: any) => {
+    // Invoke the callback with a stub `tx` so any nested side effects are reachable
+    // if the action evolves. The mock returns whatever the callback returns.
+    return cb({
+      wallet: { update: vi.fn().mockResolvedValue(wallet) },
+      walletTransaction: { create: vi.fn().mockResolvedValue(transaction) },
+    })
+  })
+  return { wallet, transaction }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("wallet/actions — topupWallet ledger wiring (issue #330)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ledgerMock.postWalletTopup.mockReset()
+    ledgerMock.postWalletTopup.mockResolvedValue({ success: true })
+  })
+
+  it("posts to the ledger after a successful top-up with the schoolId, transactionId, amount, and topupDate", async () => {
+    const { transaction } = stubSuccessfulTransaction()
+
+    const { topupWallet } = await import("../actions")
+    const result = await topupWallet(buildFormData())
+
+    expect(result.success).toBe(true)
+    expect(ledgerMock.postWalletTopup).toHaveBeenCalledTimes(1)
+    expect(ledgerMock.postWalletTopup).toHaveBeenCalledWith(SCHOOL_ID, {
+      transactionId: transaction.id,
+      amount: 150,
+      topupDate: transaction.createdAt,
+    })
+  })
+
+  it("returns success even when the ledger post resolves with success=false (fire-and-forget by design)", async () => {
+    stubSuccessfulTransaction()
+    ledgerMock.postWalletTopup.mockResolvedValue({
+      success: false,
+      errors: ["accounts not initialized"],
+    })
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { topupWallet } = await import("../actions")
+    const result = await topupWallet(buildFormData())
+
+    expect(result.success).toBe(true)
+    expect(consoleErr).toHaveBeenCalledWith(
+      "[topupWallet] postWalletTopup failed:",
+      ["accounts not initialized"]
+    )
+    consoleErr.mockRestore()
+  })
+
+  it("returns success even when the ledger post throws (e.g., import failure)", async () => {
+    stubSuccessfulTransaction()
+    ledgerMock.postWalletTopup.mockRejectedValue(new Error("boom"))
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { topupWallet } = await import("../actions")
+    const result = await topupWallet(buildFormData())
+
+    expect(result.success).toBe(true)
+    expect(consoleErr).toHaveBeenCalledWith(
+      "[topupWallet] Ledger posting threw (continuing):",
+      expect.any(Error)
+    )
+    consoleErr.mockRestore()
+  })
+
+  it("does not call the ledger when the wallet $transaction throws", async () => {
+    vi.mocked(db.$transaction).mockRejectedValue(new Error("db unavailable"))
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { topupWallet } = await import("../actions")
+    const result = await topupWallet(buildFormData())
+
+    expect(result.success).toBe(false)
+    expect(ledgerMock.postWalletTopup).not.toHaveBeenCalled()
+    consoleErr.mockRestore()
+  })
+})

--- a/src/components/school-dashboard/finance/wallet/actions.ts
+++ b/src/components/school-dashboard/finance/wallet/actions.ts
@@ -108,6 +108,30 @@ export async function topupWallet(formData: FormData) {
       return { wallet, transaction }
     })
 
+    // Post to double-entry ledger so cash + unearned-revenue accounts move.
+    // Mirrors fees/actions.ts postFeePayment wiring; fire-and-forget by design
+    // (per umbrella finance/ISSUE.md the rollback story is shared P0 work,
+    // tracked separately from wiring the orphan posters).
+    try {
+      const { postWalletTopup } = await import("../lib/accounting/actions")
+      const postResult = await postWalletTopup(session.user.schoolId, {
+        transactionId: result.transaction.id,
+        amount: validated.amount,
+        topupDate: result.transaction.createdAt,
+      })
+      if (!postResult.success) {
+        console.error(
+          "[topupWallet] postWalletTopup failed:",
+          postResult.errors
+        )
+      }
+    } catch (postingErr) {
+      console.error(
+        "[topupWallet] Ledger posting threw (continuing):",
+        postingErr
+      )
+    }
+
     revalidatePath("/finance/wallet")
     return { success: true, data: result }
   } catch (error) {


### PR DESCRIPTION
## Summary

- Wires the orphaned `postWalletTopup` so wallet top-ups post a balanced journal entry (DR Cash / CR Unearned Revenue) instead of bypassing the general ledger.
- First of the 5 orphaned posting functions called out in `finance/ISSUE.md` and the finance doc's "Honest status" — the pattern here is copy-pasteable to `postFeeAssignment`, `postSalaryPayment`, `postExpensePayment`, and `postInvoicePayment`.
- Adds the wallet module's first 4 tests (was 0% per the finance status matrix).

## Why wallet first (not invoice or salary)

Wiring `postInvoicePayment` alone would double-count revenue today: the already-wired `postFeePayment` directly recognizes revenue (DR Cash / CR Revenue), so adding an invoice post (DR Cash / CR Accounts Receivable) on the same fee→invoice→payment chain creates two cash debits per payment. The clean fix is to wire `postFeeAssignment` (AR side) at the same time and refactor `postFeePayment`, which is a larger change than "one PR per epic" allows.

`postWalletTopup` has no such coupling — top-ups are a separate cashflow (parent funds a wallet, then later draws against it for fees). DR Cash / CR Unearned Revenue is balanced and independent. It exercises the same wiring pattern, so the next four orphans can mechanical-rename their way in.

## Changes

- `wallet/actions.ts:topupWallet` — after `db.$transaction` resolves, dynamic-import `postWalletTopup` and call it with `{ transactionId, amount, topupDate }`. Wrapped in try/catch matching the documented fee-payment pattern (log on failure, do not roll back — the rollback story is shared P0 follow-up in `finance/ISSUE.md`).
- `wallet/__tests__/actions.test.ts` — new file. Four tests cover (1) happy-path wiring, (2) ledger resolves `success: false`, (3) ledger throws, (4) wallet `$transaction` fails so the ledger is never called.

## Test plan

- [x] `vitest run src/components/school-dashboard/finance/wallet/__tests__/actions.test.ts` — 4/4 pass
- [x] `tsc --noEmit` — no new errors in wallet or accounting paths (pre-existing errors in `docs/[[...slug]]/page.tsx`, `lib/source.ts`, and `tests/e2e/epic-14-guardians/*` are unrelated)
- [ ] Staging smoke: top up a wallet, verify a `JournalEntry` row appears with two balanced lines scoped by `schoolId`

## Follow-ups (out of scope for this PR)

- Wire the remaining 4 orphans using the same pattern (one PR each)
- Make `postFeePayment` transactional with rollback (P0 in `finance/ISSUE.md`, shared with all 5 wirings)
- Resolve the fee-vs-invoice double-counting design so `postInvoicePayment` can land alongside `postFeeAssignment`

Closes #330
Refs #313