### PR TITLE
fix(onboarding): MENA currencies + location-derived default on price step

### DIFF
--- a/src/components/onboarding/price/__tests__/form.test.tsx
+++ b/src/components/onboarding/price/__tests__/form.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { CURRENCY_ENUM } from "../validation"
+
+// Radix RadioGroup uses ResizeObserver internally; jsdom doesn't ship it.
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+;(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver ??=
+  StubResizeObserver as unknown as typeof ResizeObserver
+
+// ---------------------------------------------------------------------------
+// Mocks — replace the price step's siblings so the form renders in isolation.
+// ---------------------------------------------------------------------------
+
+// Hoisted state for the useListing/useDictionary mocks so each test can set
+// the school's location-derived currency before importing the component.
+const listingState = vi.hoisted(() => ({
+  current: { currency: undefined as string | undefined },
+}))
+
+vi.mock("@/components/internationalization/use-dictionary", () => ({
+  useDictionary: () => ({ dictionary: {} }),
+}))
+
+vi.mock("../../use-listing", () => ({
+  useListing: () => ({
+    listing: { currency: listingState.current.currency },
+    updateListingData: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+  useHostNavigation: () => ({
+    goToNextStep: vi.fn(),
+    goToPreviousStep: vi.fn(),
+  }),
+}))
+
+vi.mock("../../form-field", () => ({
+  FormField: ({
+    label,
+    children,
+  }: {
+    label: React.ReactNode
+    children: React.ReactNode
+  }) => (
+    <div>
+      <span>{label}</span>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock("../../step-navigation", () => ({
+  StepNavigation: () => null,
+}))
+
+vi.mock("../../step-wrapper", () => ({
+  StepWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Tests — issue #305 (MENA currencies + symbol prefix)
+// ---------------------------------------------------------------------------
+
+describe("PriceForm — currency selector (issue #305)", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    listingState.current.currency = undefined
+  })
+
+  it("renders a radio for every CURRENCY_ENUM entry (was hardcoded to 5 Western currencies)", async () => {
+    const { PriceForm } = await import("../form")
+    render(<PriceForm />)
+
+    // 14 total: USD, EUR, GBP, CAD, AUD + SAR, AED, EGP, SDG, JOD, KWD, QAR, BHD, OMR
+    expect(CURRENCY_ENUM.length).toBe(14)
+    for (const currency of CURRENCY_ENUM) {
+      expect(
+        screen.getByRole("radio", { name: currency }),
+        `radio for ${currency} should render`
+      ).toBeInTheDocument()
+    }
+  })
+
+  it("defaults to the location-derived currency on the listing (SDG for Sudan, not USD)", async () => {
+    listingState.current.currency = "SDG"
+    const { PriceForm } = await import("../form")
+    render(<PriceForm />)
+
+    const sdg = screen.getByRole("radio", { name: "SDG" })
+    expect(sdg).toBeChecked()
+    expect(screen.getByRole("radio", { name: "USD" })).not.toBeChecked()
+  })
+
+  it("falls back to USD when the listing has no currency yet", async () => {
+    listingState.current.currency = undefined
+    const { PriceForm } = await import("../form")
+    render(<PriceForm />)
+
+    expect(screen.getByRole("radio", { name: "USD" })).toBeChecked()
+  })
+
+  it("prefixes the tuition input with the SDG symbol when the listing is in SDG", async () => {
+    listingState.current.currency = "SDG"
+    const { PriceForm } = await import("../form")
+    const { container } = render(<PriceForm />)
+
+    // Three fee inputs all share the same prefix span — assert at least the
+    // first one shows the Sudanese pound symbol (was hardcoded "$" before #305).
+    const prefixes = container.querySelectorAll("span")
+    const hasSdg = Array.from(prefixes).some((el) =>
+      el.textContent?.includes("ج.س")
+    )
+    expect(hasSdg).toBe(true)
+  })
+
+  it("prefixes inputs with $ when currency is USD (regression guard)", async () => {
+    listingState.current.currency = "USD"
+    const { PriceForm } = await import("../form")
+    const { container } = render(<PriceForm />)
+
+    const prefixes = container.querySelectorAll("span")
+    const hasDollar = Array.from(prefixes).some(
+      (el) => el.textContent?.trim() === "$"
+    )
+    expect(hasDollar).toBe(true)
+  })
+})

--- a/src/components/onboarding/price/form.tsx
+++ b/src/components/onboarding/price/form.tsx
@@ -10,10 +10,32 @@ import { FormField } from "../form-field"
 import { StepNavigation } from "../step-navigation"
 import { StepWrapper } from "../step-wrapper"
 import { usePrice } from "./use-price"
+import { CURRENCY_ENUM, type Currency } from "./validation"
+
+// Display symbol per currency for the fee input prefix. Keys mirror
+// CURRENCY_ENUM so adding a currency in validation triggers a TS error here
+// — any new entry must ship with its symbol.
+const CURRENCY_SYMBOL: Record<Currency, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  CAD: "$",
+  AUD: "$",
+  SAR: "ر.س",
+  AED: "د.إ",
+  EGP: "ج.م",
+  SDG: "ج.س",
+  JOD: "د.أ",
+  KWD: "د.ك",
+  QAR: "ر.ق",
+  BHD: "د.ب",
+  OMR: "ر.ع",
+}
 
 export function PriceForm() {
   const { dictionary } = useDictionary()
   const { form, onSubmit, onBack, isLoading, error, isFormValid } = usePrice()
+  const currencySymbol = CURRENCY_SYMBOL[form.watch("currency")] ?? "$"
 
   return (
     <StepWrapper>
@@ -32,7 +54,7 @@ export function PriceForm() {
           >
             <div className="relative">
               <span className="text-muted-foreground absolute start-3 top-1/2 -translate-y-1/2 transform">
-                $
+                {currencySymbol}
               </span>
               <input
                 type="number"
@@ -58,7 +80,7 @@ export function PriceForm() {
           >
             <div className="relative">
               <span className="text-muted-foreground absolute start-3 top-1/2 -translate-y-1/2 transform">
-                $
+                {currencySymbol}
               </span>
               <input
                 type="number"
@@ -84,7 +106,7 @@ export function PriceForm() {
           >
             <div className="relative">
               <span className="text-muted-foreground absolute start-3 top-1/2 -translate-y-1/2 transform">
-                $
+                {currencySymbol}
               </span>
               <input
                 type="number"
@@ -108,16 +130,13 @@ export function PriceForm() {
             error={form.formState.errors.currency?.message}
           >
             <RadioGroup
-              defaultValue={form.getValues("currency")}
+              value={form.watch("currency")}
               onValueChange={(value: string) =>
-                form.setValue(
-                  "currency",
-                  value as "USD" | "EUR" | "GBP" | "CAD" | "AUD"
-                )
+                form.setValue("currency", value as Currency)
               }
-              className="grid grid-cols-2 gap-4 sm:grid-cols-3"
+              className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5"
             >
-              {["USD", "EUR", "GBP", "CAD", "AUD"].map((currency) => (
+              {CURRENCY_ENUM.map((currency) => (
                 <div key={currency} className="flex items-center gap-2">
                   <RadioGroupItem
                     value={currency}

--- a/src/components/onboarding/price/use-price.tsx
+++ b/src/components/onboarding/price/use-price.tsx
@@ -7,19 +7,26 @@ import { useForm } from "react-hook-form"
 
 import { STEP_NAVIGATION } from "../config.client"
 import { useHostNavigation, useListing } from "../use-listing"
-import { SchoolPriceFormData, schoolPriceSchema } from "./validation"
+import {
+  SchoolPriceFormData,
+  schoolPriceSchema,
+  type Currency,
+} from "./validation"
 
 export function usePrice() {
   const { listing, updateListingData, isLoading, error } = useListing()
   const { goToNextStep, goToPreviousStep } = useHostNavigation("price")
 
+  // Default to whatever the location step already derived (e.g. SDG for
+  // Sudan, SAR for KSA — see onboarding/location/actions.ts). Pilot #305:
+  // the form forced USD, so MENA schools had to override before saving.
   const form = useForm<SchoolPriceFormData>({
     resolver: zodResolver(schoolPriceSchema),
     defaultValues: {
       tuitionFee: 5000,
       registrationFee: 0,
       applicationFee: 0,
-      currency: "USD" as const,
+      currency: (listing?.currency ?? "USD") as Currency,
       paymentSchedule: "semester" as const,
     },
     mode: "onChange",


### PR DESCRIPTION
## Summary

Pilot #305 (Sudan) reported the onboarding price step forced USD and only offered 5 Western currencies, so MENA schools had to override before the form would save. The validation enum already shipped 14 currencies (`USD, EUR, GBP, CAD, AUD, SAR, AED, EGP, SDG, JOD, KWD, QAR, BHD, OMR`) — only the form rendering and the default-value picker lagged.

## Changes

- `form.tsx` — iterate `CURRENCY_ENUM` instead of the hardcoded 5-currency array. Prefix each fee input with the currency symbol (`ج.س` for SDG, `ر.س` for SAR, `$` for USD/CAD/AUD, etc.) instead of a hardcoded `$`. Grid bumps from 2/3 to 3/4/5 columns for the longer list.
- `use-price.tsx` — default the form's `currency` field to `listing?.currency` (which the location step auto-derives via `resolveDefaultCurrency(country)`), falling back to USD only when no listing currency is set. A Sudanese school now lands on SDG without a click.
- `__tests__/form.test.tsx` — new file. Five tests cover (1) all 14 radios render, (2) SDG listing → SDG checked, (3) no listing → USD checked, (4) SDG symbol prefix shows, (5) USD `$` prefix shows.

## Test plan

- [x] `vitest run src/components/onboarding/price/__tests__/form.test.tsx` — 5/5 pass
- [ ] Staging: onboard with Sudan as the country, land on the price step, confirm SDG is preselected and the fee inputs show ج.س
- [ ] Staging: onboard with KSA, confirm SAR is preselected and inputs show ر.س
- [ ] Staging: onboard with USA, confirm USD is preselected and inputs show $

## Why this is the Epic 02 pick

Of the open pilot-friction issues (#254 Hotmail OTP, #305 currency, #306 responsive break), #305 is the highest-leverage scoped code fix:
- #254 is a deliverability issue, not pure code (likely SPF/DKIM/sender reputation work)
- #305 unblocks the entire MENA pilot cohort visually and aligns the form with the validation/data layers that already support 14 currencies
- #306 is small but cosmetic

Closes #305
Refs #314