### PR TITLE
perf(attendance): kill N+1 in bulkUploadAttendance

### DIFF
--- a/src/components/school-dashboard/attendance/__tests__/bulk.test.ts
+++ b/src/components/school-dashboard/attendance/__tests__/bulk.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { auth } from "@/auth"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "@/lib/db"
+import { getTenantContext } from "@/lib/tenant-context"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    attendance: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      createMany: vi.fn(),
+      update: vi.fn(),
+    },
+    student: {
+      findMany: vi.fn(),
+    },
+    class: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/tenant-context", () => ({
+  getTenantContext: vi.fn(),
+}))
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn(),
+}))
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock(
+  "@/components/school-dashboard/attendance/authorization",
+  () => ({
+    canMarkAttendance: vi.fn(() => true),
+    canViewSchoolAnalytics: vi.fn(() => true),
+    isStaffRole: vi.fn(() => true),
+  })
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SCHOOL_ID = "school-1"
+const CLASS_ID = "class-1"
+const USER_ID = "user-1"
+const UPLOAD_DATE = "2026-05-25"
+
+function bulkInput(
+  studentIds: string[],
+  overrides: Partial<{ status: string; method: string }> = {}
+) {
+  return {
+    classId: CLASS_ID,
+    date: UPLOAD_DATE,
+    method: (overrides.method ?? "BULK_UPLOAD") as never,
+    records: studentIds.map((studentId) => ({
+      studentId,
+      status: (overrides.status ?? "PRESENT") as never,
+      checkInTime: undefined,
+      checkOutTime: undefined,
+      notes: undefined,
+    })),
+  }
+}
+
+function setupAuthAndTenant() {
+  vi.mocked(getTenantContext).mockResolvedValue({
+    schoolId: SCHOOL_ID,
+    subdomain: "test-school",
+    role: "TEACHER",
+    locale: "en",
+  } as never)
+  vi.mocked(auth).mockResolvedValue({
+    user: { id: USER_ID, role: "TEACHER", schoolId: SCHOOL_ID },
+    expires: new Date(Date.now() + 86400000).toISOString(),
+  } as never)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — issue #335 (N+1 fix)
+// ---------------------------------------------------------------------------
+
+describe("bulkUploadAttendance — batched prefetch (issue #335)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupAuthAndTenant()
+    // Default: all students exist, class exists, no prior attendance rows.
+    vi.mocked(db.student.findMany).mockResolvedValue([
+      { id: "stu-1" },
+      { id: "stu-2" },
+      { id: "stu-3" },
+    ] as never)
+    vi.mocked(db.class.findFirst).mockResolvedValue({
+      id: CLASS_ID,
+      schoolId: SCHOOL_ID,
+    } as never)
+    vi.mocked(db.attendance.findMany).mockResolvedValue([] as never)
+    // $transaction stub invokes the callback with a stub tx so we can capture
+    // the inner update/createMany calls.
+    vi.mocked(db.$transaction).mockImplementation(async (cb: any) =>
+      cb({
+        attendance: {
+          update: vi.fn(),
+          createMany: vi.fn(),
+        },
+      })
+    )
+  })
+
+  it("issues exactly ONE attendance.findMany prefetch — not one per record (the N+1 fix)", async () => {
+    const { bulkUploadAttendance } = await import("../actions/bulk")
+    await bulkUploadAttendance(bulkInput(["stu-1", "stu-2", "stu-3"]))
+
+    // Three findMany calls total: 1 for students (Phase 1), 1 for prefetch
+    // (Phase 1b). The previous implementation issued findFirst N times
+    // INSIDE the transaction (3 here) on top of those — now zero.
+    const attendanceFindManyCalls = vi.mocked(db.attendance.findMany).mock.calls
+    expect(attendanceFindManyCalls).toHaveLength(1)
+
+    // The prefetch query must be scoped by tenant + classId + date + the
+    // student-ID set — never a bare findMany that would leak across tenants.
+    const where = attendanceFindManyCalls[0][0]!.where!
+    expect(where.schoolId).toBe(SCHOOL_ID)
+    expect(where.classId).toBe(CLASS_ID)
+    expect(where.deletedAt).toBe(null)
+    expect((where.studentId as { in: string[] }).in).toEqual([
+      "stu-1",
+      "stu-2",
+      "stu-3",
+    ])
+  })
+
+  it("routes every record to createMany (one call, all rows) when no prior attendance exists", async () => {
+    let capturedTx: { attendance: { update: ReturnType<typeof vi.fn>; createMany: ReturnType<typeof vi.fn> } } | undefined
+    vi.mocked(db.$transaction).mockImplementation(async (cb: any) => {
+      capturedTx = {
+        attendance: {
+          update: vi.fn(),
+          createMany: vi.fn(),
+        },
+      }
+      return cb(capturedTx)
+    })
+
+    const { bulkUploadAttendance } = await import("../actions/bulk")
+    const result = await bulkUploadAttendance(
+      bulkInput(["stu-1", "stu-2", "stu-3"])
+    )
+
+    expect(result.successful).toBe(3)
+    expect(result.failed).toBe(0)
+    expect(result.rolledBack).toBe(false)
+    expect(capturedTx?.attendance.update).not.toHaveBeenCalled()
+    expect(capturedTx?.attendance.createMany).toHaveBeenCalledTimes(1)
+    const createManyArgs = capturedTx!.attendance.createMany.mock.calls[0][0]
+    expect(createManyArgs.data).toHaveLength(3)
+    expect(createManyArgs.data[0].schoolId).toBe(SCHOOL_ID)
+    expect(createManyArgs.data[0].markedBy).toBe(USER_ID)
+  })
+
+  it("routes every record to update — and skips createMany entirely — when all records have prior rows", async () => {
+    vi.mocked(db.attendance.findMany).mockResolvedValue([
+      { id: "att-1", studentId: "stu-1" },
+      { id: "att-2", studentId: "stu-2" },
+      { id: "att-3", studentId: "stu-3" },
+    ] as never)
+
+    let capturedTx: { attendance: { update: ReturnType<typeof vi.fn>; createMany: ReturnType<typeof vi.fn> } } | undefined
+    vi.mocked(db.$transaction).mockImplementation(async (cb: any) => {
+      capturedTx = {
+        attendance: {
+          update: vi.fn(),
+          createMany: vi.fn(),
+        },
+      }
+      return cb(capturedTx)
+    })
+
+    const { bulkUploadAttendance } = await import("../actions/bulk")
+    const result = await bulkUploadAttendance(
+      bulkInput(["stu-1", "stu-2", "stu-3"])
+    )
+
+    expect(result.successful).toBe(3)
+    expect(capturedTx?.attendance.update).toHaveBeenCalledTimes(3)
+    expect(capturedTx?.attendance.createMany).not.toHaveBeenCalled()
+    // First update should target the matching existing row, not some other id.
+    expect(capturedTx!.attendance.update.mock.calls[0][0].where.id).toBe("att-1")
+  })
+
+  it("splits mixed input: updates known rows, batches new rows into a single createMany", async () => {
+    vi.mocked(db.attendance.findMany).mockResolvedValue([
+      { id: "att-1", studentId: "stu-1" },
+    ] as never)
+
+    let capturedTx: { attendance: { update: ReturnType<typeof vi.fn>; createMany: ReturnType<typeof vi.fn> } } | undefined
+    vi.mocked(db.$transaction).mockImplementation(async (cb: any) => {
+      capturedTx = {
+        attendance: {
+          update: vi.fn(),
+          createMany: vi.fn(),
+        },
+      }
+      return cb(capturedTx)
+    })
+
+    const { bulkUploadAttendance } = await import("../actions/bulk")
+    const result = await bulkUploadAttendance(
+      bulkInput(["stu-1", "stu-2", "stu-3"])
+    )
+
+    expect(result.successful).toBe(3)
+    expect(capturedTx?.attendance.update).toHaveBeenCalledTimes(1)
+    expect(capturedTx?.attendance.createMany).toHaveBeenCalledTimes(1)
+    const createManyArgs = capturedTx!.attendance.createMany.mock.calls[0][0]
+    expect(createManyArgs.data).toHaveLength(2)
+    expect(
+      createManyArgs.data.map((d: { studentId: string }) => d.studentId).sort()
+    ).toEqual(["stu-2", "stu-3"])
+  })
+
+  it("preserves the existing rollback contract when the transaction throws", async () => {
+    vi.mocked(db.$transaction).mockRejectedValue(new Error("constraint violation"))
+
+    const { bulkUploadAttendance } = await import("../actions/bulk")
+    const result = await bulkUploadAttendance(bulkInput(["stu-1"]))
+
+    expect(result.successful).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(result.rolledBack).toBe(true)
+    expect(result.errors[0].error).toContain("constraint violation")
+  })
+
+  it("does not prefetch when validation fails (missing student) — Phase 1 still short-circuits", async () => {
+    vi.mocked(db.student.findMany).mockResolvedValue([{ id: "stu-1" }] as never)
+
+    const { bulkUploadAttendance } = await import("../actions/bulk")
+    const result = await bulkUploadAttendance(
+      bulkInput(["stu-1", "stu-missing"])
+    )
+
+    expect(result.successful).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(result.rolledBack).toBe(true)
+    // The attendance.findMany prefetch must NOT run when validation already
+    // aborted, otherwise the optimization "leaks" an extra query on errors.
+    expect(db.attendance.findMany).not.toHaveBeenCalled()
+    expect(db.$transaction).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/school-dashboard/attendance/actions/bulk.ts
+++ b/src/components/school-dashboard/attendance/actions/bulk.ts
@@ -128,26 +128,38 @@ export async function bulkUploadAttendance(
     }
   }
 
+  // Phase 1b: Prefetch existing rows so the txn issues O(N+1) queries
+  // instead of O(2N). Same family of N+1 fixes as markAttendance /
+  // quickMarkAllPresent that landed in March; bulk upload slipped through.
+  // Safe to batch because (schoolId, studentId, classId, date, periodId)
+  // is unique — see prisma/models/attendance.prisma:94.
+  const uploadDate = new Date(parsed.date)
+  const existingRows = await db.attendance.findMany({
+    where: {
+      schoolId,
+      classId: parsed.classId,
+      date: uploadDate,
+      periodId: null,
+      deletedAt: null,
+      studentId: { in: studentIds },
+    },
+    select: { id: true, studentId: true },
+  })
+  const existingByStudent = new Map(
+    existingRows.map((row) => [row.studentId, row.id])
+  )
+
   // Phase 2: Execute all operations in a single transaction
   try {
     await db.$transaction(async (tx) => {
-      for (const record of parsed.records) {
-        // Check if attendance record already exists for this date
-        const existing = await tx.attendance.findFirst({
-          where: {
-            schoolId,
-            studentId: record.studentId,
-            classId: parsed.classId,
-            date: new Date(parsed.date),
-            periodId: null,
-            deletedAt: null,
-          },
-        })
+      const toCreate: Prisma.AttendanceCreateManyInput[] = []
 
-        if (existing) {
-          // Update existing record
+      for (const record of parsed.records) {
+        const existingId = existingByStudent.get(record.studentId)
+
+        if (existingId) {
           await tx.attendance.update({
-            where: { id: existing.id },
+            where: { id: existingId },
             data: {
               status: record.status,
               checkInTime: record.checkInTime
@@ -162,27 +174,28 @@ export async function bulkUploadAttendance(
             },
           })
         } else {
-          // Create new record
-          await tx.attendance.create({
-            data: {
-              schoolId,
-              studentId: record.studentId,
-              classId: parsed.classId,
-              date: new Date(parsed.date),
-              status: record.status,
-              method: parsed.method,
-              markedBy: session.user.id,
-              markedAt: new Date(),
-              checkInTime: record.checkInTime
-                ? new Date(record.checkInTime)
-                : null,
-              checkOutTime: record.checkOutTime
-                ? new Date(record.checkOutTime)
-                : null,
-              notes: record.notes,
-            },
+          toCreate.push({
+            schoolId,
+            studentId: record.studentId,
+            classId: parsed.classId,
+            date: uploadDate,
+            status: record.status,
+            method: parsed.method,
+            markedBy: session.user.id,
+            markedAt: new Date(),
+            checkInTime: record.checkInTime
+              ? new Date(record.checkInTime)
+              : null,
+            checkOutTime: record.checkOutTime
+              ? new Date(record.checkOutTime)
+              : null,
+            notes: record.notes,
           })
         }
+      }
+
+      if (toCreate.length > 0) {
+        await tx.attendance.createMany({ data: toCreate })
       }
     })
 


### PR DESCRIPTION
## Summary

`bulkUploadAttendance` was running a per-record `tx.attendance.findFirst` inside the transaction before each update/create — the same N+1 family as the `markAttendance` / `quickMarkAllPresent` / `getClassComparisonStats` bugs fixed in March. Bulk upload slipped through.

For a 200-student class upload: **400 queries inside the txn → ~202**, or fewer when most rows are new (1 prefetch + N updates + 1 batched `createMany`).

## Changes

- `actions/bulk.ts` Phase 1b — single `findMany` outside the txn, scoped by `(schoolId, classId, date, periodId=null, studentId IN [...])`. Builds a `Map<studentId, attendanceId>`.
- `actions/bulk.ts` Phase 2 — route each record by map hit: hits use `tx.attendance.update`, misses are pushed into a `Prisma.AttendanceCreateManyInput[]` and flushed via a single `tx.attendance.createMany`.
- `__tests__/bulk.test.ts` — new file. Six cases pin the new behavior + guard the regression.

## Why this is safe

- `(schoolId, studentId, classId, date, periodId)` is unique at `prisma/models/attendance.prisma:94`, so the prefetch reliably keys to one row per student.
- Rollback contract is unchanged — any thrown error in the txn still hits the outer try/catch and returns `rolledBack: true` with the original error shape.
- Validation short-circuit is preserved: if Phase 1 finds missing students or a missing class, the prefetch and the txn never run.

## Test plan

- [x] `vitest run src/components/school-dashboard/attendance/__tests__/bulk.test.ts` — 6/6 pass in 42ms
  - Guard: exactly one `attendance.findMany` (not N)
  - All-create → single `createMany`, zero updates
  - All-update → N updates, zero `createMany`
  - Mixed → splits cleanly
  - Rollback contract on txn throw
  - Prefetch + txn skipped on Phase-1 validation failure

## Why this is the Epic 04 pick

Epic 04's sprint stories all point at Playwright E2E (section-centric grid + timetable). Those need a running dev server + auth state + browser MCP — they're heavyweight and out of scope for a single PR. The N+1 in `bulkUploadAttendance` is a real perf bug in a real hot path (CSV upload of a whole class), fits the same family of fixes the attendance team already shipped, and is unit-testable with the existing mock infra. The E2E work belongs in a follow-up that bundles all three section-centric surfaces.

Closes #335