### PR TITLE
feat(stream): per-school video storage quota service

### DIFF
--- a/src/components/stream/lib/__tests__/quota.test.ts
+++ b/src/components/stream/lib/__tests__/quota.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "@/lib/db"
+
+import {
+  checkSchoolVideoQuota,
+  decrementSchoolVideoUsage,
+  getSchoolVideoUsage,
+  incrementSchoolVideoUsage,
+} from "../quota"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    school: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+const SCHOOL_ID = "school-1"
+const GB = BigInt(1024) * BigInt(1024) * BigInt(1024)
+
+function stubSchool(opts: {
+  used?: bigint | null
+  quota?: bigint | null
+}) {
+  vi.mocked(db.school.findUnique).mockResolvedValue({
+    videoStorageUsedBytes: opts.used ?? null,
+    videoStorageQuotaBytes: opts.quota ?? null,
+  } as never)
+}
+
+// ---------------------------------------------------------------------------
+// getSchoolVideoUsage
+// ---------------------------------------------------------------------------
+
+describe("getSchoolVideoUsage", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns unlimited when quota is null (schema default for new schools)", async () => {
+    stubSchool({ used: BigInt(500), quota: null })
+    const usage = await getSchoolVideoUsage(SCHOOL_ID)
+    expect(usage.isUnlimited).toBe(true)
+    expect(usage.quota).toBe(null)
+    expect(usage.available).toBe(null)
+    expect(usage.percentUsed).toBe(null)
+    expect(usage.used).toBe(BigInt(500))
+  })
+
+  it("returns zero used + unlimited for an unknown school (no row found)", async () => {
+    vi.mocked(db.school.findUnique).mockResolvedValue(null as never)
+    const usage = await getSchoolVideoUsage(SCHOOL_ID)
+    expect(usage.used).toBe(BigInt(0))
+    expect(usage.isUnlimited).toBe(true)
+  })
+
+  it("computes available + percentUsed when quota is configured", async () => {
+    stubSchool({ used: GB, quota: GB * BigInt(4) })
+    const usage = await getSchoolVideoUsage(SCHOOL_ID)
+    expect(usage.isUnlimited).toBe(false)
+    expect(usage.quota).toBe(GB * BigInt(4))
+    expect(usage.available).toBe(GB * BigInt(3))
+    expect(usage.percentUsed).toBe(25)
+  })
+
+  it("clamps percentUsed at 100 when over quota (display-friendly)", async () => {
+    stubSchool({ used: GB * BigInt(5), quota: GB * BigInt(4) })
+    const usage = await getSchoolVideoUsage(SCHOOL_ID)
+    expect(usage.percentUsed).toBe(100)
+    expect(usage.available).toBe(BigInt(0))
+  })
+
+  it("returns 0 percent + 0 available for a zero quota (school admin set 0 explicitly)", async () => {
+    stubSchool({ used: BigInt(100), quota: BigInt(0) })
+    const usage = await getSchoolVideoUsage(SCHOOL_ID)
+    expect(usage.percentUsed).toBe(0)
+    expect(usage.available).toBe(BigInt(0))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkSchoolVideoQuota
+// ---------------------------------------------------------------------------
+
+describe("checkSchoolVideoQuota", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("allows any size when quota is null (unconfigured = unlimited)", async () => {
+    stubSchool({ used: BigInt(0), quota: null })
+    const r = await checkSchoolVideoQuota(SCHOOL_ID, GB * BigInt(100))
+    expect(r.allowed).toBe(true)
+  })
+
+  it("allows a request that exactly fills the remaining space (inclusive)", async () => {
+    stubSchool({ used: GB, quota: GB * BigInt(2) })
+    const r = await checkSchoolVideoQuota(SCHOOL_ID, GB)
+    expect(r.allowed).toBe(true)
+  })
+
+  it("denies a request one byte over the available space", async () => {
+    stubSchool({ used: GB, quota: GB * BigInt(2) })
+    const r = await checkSchoolVideoQuota(SCHOOL_ID, GB + BigInt(1))
+    expect(r.allowed).toBe(false)
+  })
+
+  it("accepts plain JS numbers for the requestedBytes arg (callers won't always have BigInts)", async () => {
+    stubSchool({ used: BigInt(0), quota: BigInt(10_000) })
+    const r = await checkSchoolVideoQuota(SCHOOL_ID, 5_000)
+    expect(r.allowed).toBe(true)
+    expect(r.requested).toBe(BigInt(5000))
+  })
+
+  it("throws when requestedBytes is negative", async () => {
+    stubSchool({ used: BigInt(0), quota: GB })
+    await expect(checkSchoolVideoQuota(SCHOOL_ID, -1)).rejects.toThrow(
+      /non-negative/
+    )
+  })
+
+  it("returns the full usage shape so callers can render error messages without a second query", async () => {
+    stubSchool({ used: GB, quota: GB * BigInt(2) })
+    const r = await checkSchoolVideoQuota(SCHOOL_ID, GB * BigInt(2))
+    expect(r.allowed).toBe(false)
+    expect(r.used).toBe(GB)
+    expect(r.quota).toBe(GB * BigInt(2))
+    expect(r.available).toBe(GB)
+    expect(r.percentUsed).toBe(50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// incrementSchoolVideoUsage
+// ---------------------------------------------------------------------------
+
+describe("incrementSchoolVideoUsage", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("issues an atomic `increment` to keep concurrent uploads race-safe", async () => {
+    vi.mocked(db.school.update).mockResolvedValue({
+      videoStorageUsedBytes: GB,
+    } as never)
+
+    const next = await incrementSchoolVideoUsage(SCHOOL_ID, GB)
+    expect(next).toBe(GB)
+    expect(db.school.update).toHaveBeenCalledWith({
+      where: { id: SCHOOL_ID },
+      data: { videoStorageUsedBytes: { increment: GB } },
+      select: { videoStorageUsedBytes: true },
+    })
+  })
+
+  it("short-circuits a 0-byte delta (no DB write, returns current usage)", async () => {
+    stubSchool({ used: BigInt(123), quota: GB })
+    const next = await incrementSchoolVideoUsage(SCHOOL_ID, 0)
+    expect(next).toBe(BigInt(123))
+    expect(db.school.update).not.toHaveBeenCalled()
+  })
+
+  it("throws on a negative delta (use decrement instead)", async () => {
+    await expect(incrementSchoolVideoUsage(SCHOOL_ID, -1)).rejects.toThrow(
+      /non-negative/
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// decrementSchoolVideoUsage
+// ---------------------------------------------------------------------------
+
+describe("decrementSchoolVideoUsage", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("subtracts delta from current usage", async () => {
+    stubSchool({ used: GB * BigInt(3), quota: GB * BigInt(10) })
+    vi.mocked(db.school.update).mockResolvedValue({
+      videoStorageUsedBytes: GB * BigInt(2),
+    } as never)
+
+    const next = await decrementSchoolVideoUsage(SCHOOL_ID, GB)
+    expect(next).toBe(GB * BigInt(2))
+    expect(db.school.update).toHaveBeenCalledWith({
+      where: { id: SCHOOL_ID },
+      data: { videoStorageUsedBytes: GB * BigInt(2) },
+      select: { videoStorageUsedBytes: true },
+    })
+  })
+
+  it("clamps at 0 when delta exceeds current usage (double-fire delete safety)", async () => {
+    stubSchool({ used: GB, quota: GB * BigInt(10) })
+    vi.mocked(db.school.update).mockResolvedValue({
+      videoStorageUsedBytes: BigInt(0),
+    } as never)
+
+    const next = await decrementSchoolVideoUsage(SCHOOL_ID, GB * BigInt(5))
+    expect(next).toBe(BigInt(0))
+    const writeArgs = vi.mocked(db.school.update).mock.calls[0][0]
+    expect(writeArgs.data).toEqual({ videoStorageUsedBytes: BigInt(0) })
+  })
+
+  it("short-circuits a 0-byte delta", async () => {
+    stubSchool({ used: GB, quota: GB * BigInt(10) })
+    const next = await decrementSchoolVideoUsage(SCHOOL_ID, 0)
+    expect(next).toBe(GB)
+    expect(db.school.update).not.toHaveBeenCalled()
+  })
+
+  it("throws on a negative delta (use increment instead)", async () => {
+    await expect(decrementSchoolVideoUsage(SCHOOL_ID, -1)).rejects.toThrow(
+      /non-negative/
+    )
+  })
+})

--- a/src/components/stream/lib/quota.ts
+++ b/src/components/stream/lib/quota.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+/**
+ * Per-school video storage quota service.
+ *
+ * Wraps the four primitives every video upload caller needs. The schema
+ * fields (School.videoStorageUsedBytes, School.videoStorageQuotaBytes) ship
+ * unused; this module turns intent into enforcement.
+ *
+ * BigInt-safe throughout (schema uses BigInt). null quota = unlimited.
+ * Atomic increment/decrement so concurrent uploads don't race.
+ */
+
+import { db } from "@/lib/db"
+
+export interface SchoolVideoUsage {
+  used: bigint
+  quota: bigint | null
+  available: bigint | null
+  percentUsed: number | null
+  isUnlimited: boolean
+}
+
+export interface QuotaCheckResult extends SchoolVideoUsage {
+  allowed: boolean
+  requested: bigint
+}
+
+/**
+ * Read the school's current usage + quota. Returns zeros for an unknown
+ * school rather than throwing — the caller can treat that as "no quota
+ * configured" the same way they treat unlimited.
+ */
+export async function getSchoolVideoUsage(
+  schoolId: string
+): Promise<SchoolVideoUsage> {
+  const school = await db.school.findUnique({
+    where: { id: schoolId },
+    select: {
+      videoStorageUsedBytes: true,
+      videoStorageQuotaBytes: true,
+    },
+  })
+
+  const used = school?.videoStorageUsedBytes ?? BigInt(0)
+  const quota = school?.videoStorageQuotaBytes ?? null
+
+  if (quota === null) {
+    return {
+      used,
+      quota: null,
+      available: null,
+      percentUsed: null,
+      isUnlimited: true,
+    }
+  }
+
+  const available = quota > used ? quota - used : BigInt(0)
+  const percentUsed = quota === BigInt(0) ? 0 : computePercent(used, quota)
+
+  return { used, quota, available, percentUsed, isUnlimited: false }
+}
+
+/**
+ * Predicate every upload caller should hit before accepting bytes. Always
+ * returns allowed=true when the school has no quota set (null = unlimited
+ * per the schema comment). Allowed when used + requested <= quota.
+ */
+export async function checkSchoolVideoQuota(
+  schoolId: string,
+  requestedBytes: bigint | number
+): Promise<QuotaCheckResult> {
+  const requested = toBigInt(requestedBytes)
+  if (requested < BigInt(0)) {
+    throw new Error("requestedBytes must be non-negative")
+  }
+  const usage = await getSchoolVideoUsage(schoolId)
+  const allowed = usage.isUnlimited
+    ? true
+    : usage.used + requested <= (usage.quota as bigint)
+  return { ...usage, allowed, requested }
+}
+
+/**
+ * Atomically bump used bytes after a successful upload. Use `db.$transaction`
+ * upstream if you need check-then-write atomicity across both calls; the
+ * increment itself is atomic at the row level.
+ */
+export async function incrementSchoolVideoUsage(
+  schoolId: string,
+  deltaBytes: bigint | number
+): Promise<bigint> {
+  const delta = toBigInt(deltaBytes)
+  if (delta < BigInt(0)) {
+    throw new Error("deltaBytes must be non-negative for increment")
+  }
+  if (delta === BigInt(0)) {
+    // Nothing to write — short-circuit so callers can pass through a 0-byte
+    // edge case (empty file, paused upload) without an extra DB roundtrip.
+    return (await getSchoolVideoUsage(schoolId)).used
+  }
+
+  const updated = await db.school.update({
+    where: { id: schoolId },
+    data: { videoStorageUsedBytes: { increment: delta } },
+    select: { videoStorageUsedBytes: true },
+  })
+  return updated.videoStorageUsedBytes ?? BigInt(0)
+}
+
+/**
+ * Atomically reduce used bytes after a delete. Clamps at 0 so a double-fire
+ * delete (e.g., webhook retry + manual cleanup) never produces a negative
+ * counter that future quota checks would misinterpret.
+ */
+export async function decrementSchoolVideoUsage(
+  schoolId: string,
+  deltaBytes: bigint | number
+): Promise<bigint> {
+  const delta = toBigInt(deltaBytes)
+  if (delta < BigInt(0)) {
+    throw new Error("deltaBytes must be non-negative for decrement")
+  }
+  if (delta === BigInt(0)) {
+    return (await getSchoolVideoUsage(schoolId)).used
+  }
+
+  // Clamp at zero: re-read used, compute max(0, used - delta), write back.
+  // Trades atomicity for correctness on the clamp — the alternative
+  // ({ decrement: delta }) can go negative on double-fire.
+  const current = await getSchoolVideoUsage(schoolId)
+  const next = current.used > delta ? current.used - delta : BigInt(0)
+
+  const updated = await db.school.update({
+    where: { id: schoolId },
+    data: { videoStorageUsedBytes: next },
+    select: { videoStorageUsedBytes: true },
+  })
+  return updated.videoStorageUsedBytes ?? BigInt(0)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toBigInt(value: bigint | number): bigint {
+  if (typeof value === "bigint") return value
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new Error("byte counts must be finite integers or bigints")
+  }
+  return BigInt(value)
+}
+
+function computePercent(used: bigint, quota: bigint): number {
+  // BigInt division truncates; multiply first to keep two decimals of
+  // precision. Capping at 100 because over-quota math should still display
+  // as "full" rather than 137%.
+  const raw = Number((used * BigInt(10000)) / quota) / 100
+  return raw > 100 ? 100 : raw
+}


### PR DESCRIPTION
## Summary

`School.videoStorageUsedBytes` and `School.videoStorageQuotaBytes` ship in the schema (`prisma/models/school.prisma:49-50`) but have **zero callers** — quota intent is documented, nothing checks or maintains it. This PR adds the four primitives every future upload caller will use, with tests, and zero behavior change to live code.

## Primitives

- `getSchoolVideoUsage(schoolId)` — read used/quota/available/percentUsed, treats null quota as unlimited
- `checkSchoolVideoQuota(schoolId, requestedBytes)` — predicate to gate uploads
- `incrementSchoolVideoUsage(schoolId, deltaBytes)` — atomic post-upload
- `decrementSchoolVideoUsage(schoolId, deltaBytes)` — clamped post-delete

## Design notes worth reviewing

- **BigInt throughout** to match the schema column type. Public API accepts plain `number` for ergonomics and converts.
- **null quota = unlimited** (matches schema comment "null = unlimited") — never blocks an unconfigured school.
- **Atomic `increment`** on the write path so two concurrent uploads can't both pass `check`, both write, and lose one of the byte counts.
- **`decrement` clamps at 0** via read-then-write so a double-fire delete (webhook retry + manual cleanup) doesn't produce a negative counter that future quota checks would misinterpret. Trades atomicity for correctness on the clamp.
- **`percentUsed` caps at 100** so the future admin UI reads "full" rather than 137% if a school somehow goes over.

## Test plan

- [x] `vitest run src/components/stream/lib/__tests__/quota.test.ts` — 18/18 pass in 4ms
  - usage: unlimited, unknown school, configured, over-quota clamp, zero-quota
  - check: unlimited allows, exact-fit inclusive, one-byte-over denies, plain number arg, negative throws, full shape returned
  - increment: atomic `{ increment }`, 0-byte short-circuit, negative throws
  - decrement: subtraction, clamp at 0 on over-shoot, 0-byte short-circuit, negative throws

## Why service-first (not wired enforcement)

The upload flow is multi-actor — presign endpoint, `uploadVideo` server action, mobile API (planned Epic 09), direct-S3 admin uploads. Wiring quota into all four in one PR is the wrong shape: they have different auth contexts and error semantics. A typed, tested service unblocks each as a one-line call in a follow-up.

## Follow-ups (separate issues)

- Wire in `uploadVideo` server action (gate + increment after successful video.create)
- Wire decrement into `video-actions.ts` / `video-owner-actions.ts` delete paths
- Storage-quota indicator on the school admin surface (reads `getSchoolVideoUsage`)

Closes #337