### PR TITLE
test(rbac): role-matrix coverage (ui-permissions + sales + finance)

### DIFF
--- a/src/components/school-dashboard/finance/__tests__/permissions.test.ts
+++ b/src/components/school-dashboard/finance/__tests__/permissions.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { describe, expect, it } from "vitest"
+
+import { ALL_ROLES, type Role } from "@/lib/rbac/types"
+import {
+  FULL_UI_PERMISSIONS,
+  NO_UI_PERMISSIONS,
+} from "@/lib/rbac/ui-permissions"
+
+import {
+  buildFinanceSubTabs,
+  getFeesTabs,
+  getFinanceRootTabs,
+  getUIConfigForRole,
+} from "../permissions"
+
+// Finance policy buckets — change here if policy intentionally moves a role.
+const FINANCE_WRITE: ReadonlyArray<Role> = ["DEVELOPER", "ADMIN", "ACCOUNTANT"]
+const FEES_VIEW: ReadonlyArray<Role> = [
+  "DEVELOPER",
+  "ADMIN",
+  "ACCOUNTANT",
+  "STUDENT",
+  "GUARDIAN",
+  "STAFF",
+  "TEACHER",
+]
+// USER is intentionally excluded — neither a finance writer nor a fees viewer.
+
+// ---------------------------------------------------------------------------
+// getFinanceRootTabs
+// ---------------------------------------------------------------------------
+
+describe("finance/permissions — getFinanceRootTabs", () => {
+  it.each(ALL_ROLES)(
+    "%s gets the full 13-tab list iff they're a finance writer",
+    (role) => {
+      const tabs = getFinanceRootTabs(role, "en")
+      if (FINANCE_WRITE.includes(role)) {
+        // 7 visible: overview, invoice, banking, fees, salary, payroll, reports
+        // 6 hidden: receipt, timesheet, wallet, budget, expenses, accounts
+        expect(tabs.length).toBe(13)
+        const labels = tabs.map((t) => t.name)
+        expect(labels).toContain("Overview")
+        expect(labels).toContain("Invoice")
+        expect(labels).toContain("Payroll")
+      } else {
+        // Non-writers get a 2-tab "viewer" list (Overview + Fees) so they
+        // can at least see their own balance.
+        expect(tabs.length).toBe(2)
+        expect(tabs.map((t) => t.name)).toEqual(["Overview", "Fees"])
+      }
+    }
+  )
+
+  it("hides 6 of 13 tabs behind hidden:true for writers (sidebar shows 7 primary)", () => {
+    const tabs = getFinanceRootTabs("ADMIN", "en")
+    const visible = tabs.filter((t) => !t.hidden)
+    const hidden = tabs.filter((t) => t.hidden)
+    expect(visible.length).toBe(7)
+    expect(hidden.length).toBe(6)
+  })
+
+  it("honors the lang param across both writer + viewer paths", () => {
+    expect(getFinanceRootTabs("ADMIN", "ar")[0].href).toBe("/ar/finance")
+    expect(getFinanceRootTabs("STUDENT", "ar")[0].href).toBe("/ar/finance")
+    expect(getFinanceRootTabs("STUDENT", "ar")[1].href).toBe("/ar/finance/fees")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getFeesTabs
+// ---------------------------------------------------------------------------
+
+describe("finance/permissions — getFeesTabs", () => {
+  it.each(ALL_ROLES)(
+    "%s gets the right Fees tabs based on role",
+    (role) => {
+      const tabs = getFeesTabs(role, "en")
+      const isWriter = FINANCE_WRITE.includes(role)
+      const isViewer = FEES_VIEW.includes(role)
+
+      if (isWriter) {
+        // 7 admin tabs: overview/structures/assignments/payments/scholarships/fines/reports
+        expect(tabs.length).toBe(7)
+        expect(tabs[0].href).toBe("/en/finance/fees")
+      } else if (isViewer) {
+        // Student/Guardian/Staff/Teacher get a single "My Fees" tab
+        expect(tabs.length).toBe(1)
+        expect(tabs[0].href).toBe("/en/finance/fees/my")
+      } else {
+        // USER + (no-one else currently) get []
+        expect(tabs).toEqual([])
+      }
+    }
+  )
+
+  it("returns [] for null/undefined (logged-out)", () => {
+    expect(getFeesTabs(null, "en")).toEqual([])
+    expect(getFeesTabs(undefined, "en")).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildFinanceSubTabs
+// ---------------------------------------------------------------------------
+
+describe("finance/permissions — buildFinanceSubTabs", () => {
+  const SAMPLE_CONFIG = {
+    tabs: [
+      { key: "overview", segment: "", defaultLabel: "Overview" },
+      { key: "structures", segment: "structures", defaultLabel: "Structures" },
+    ],
+  }
+
+  it("returns [] for non-finance-writer roles", () => {
+    for (const role of ALL_ROLES) {
+      if (FINANCE_WRITE.includes(role)) continue
+      expect(
+        buildFinanceSubTabs(role, "en", "wallet", SAMPLE_CONFIG)
+      ).toEqual([])
+    }
+  })
+
+  it("builds module-specific tabs for finance writers", () => {
+    const tabs = buildFinanceSubTabs("ACCOUNTANT", "en", "wallet", SAMPLE_CONFIG)
+    expect(tabs).toEqual([
+      { name: "Overview", href: "/en/finance/wallet" },
+      { name: "Structures", href: "/en/finance/wallet/structures" },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getUIConfigForRole
+// ---------------------------------------------------------------------------
+
+describe("finance/permissions — getUIConfigForRole", () => {
+  it.each(ALL_ROLES)("%s gets the right UIPermissions shape", (role) => {
+    const config = getUIConfigForRole(role)
+    if (FINANCE_WRITE.includes(role)) {
+      expect(config).toEqual(FULL_UI_PERMISSIONS)
+    } else {
+      // Non-writers get a read-only shape (explicit override of just the
+      // readOnlyMode flag on top of NO_UI_PERMISSIONS).
+      expect(config.readOnlyMode).toBe(true)
+      // Every action flag must be denied for non-writers.
+      const denyFlags = Object.entries(config).filter(
+        ([k]) => k !== "readOnlyMode"
+      )
+      for (const [k, v] of denyFlags) {
+        expect(v, `${k} should be false for ${role}`).toBe(false)
+      }
+    }
+  })
+
+  it("returns NO_UI_PERMISSIONS for null role (logged-out)", () => {
+    expect(getUIConfigForRole(null)).toEqual(NO_UI_PERMISSIONS)
+  })
+})

--- a/src/components/school-dashboard/sales/__tests__/permissions.test.ts
+++ b/src/components/school-dashboard/sales/__tests__/permissions.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2025-present databayt/databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { describe, expect, it } from "vitest"
+
+import { ALL_ROLES, type Role } from "@/lib/rbac/types"
+import {
+  FULL_UI_PERMISSIONS,
+  NO_UI_PERMISSIONS,
+} from "@/lib/rbac/ui-permissions"
+
+import { getTabsForRole, getUIConfigForRole } from "../permissions"
+
+// Policy: ADMIN + DEVELOPER get full sales pipeline; every other role gets
+// nothing. The matrix below is the policy — change it intentionally if you
+// change the implementation.
+const SALES_ADMIN_ROLES: ReadonlyArray<Role> = ["DEVELOPER", "ADMIN"]
+
+describe("sales/permissions — getTabsForRole", () => {
+  it.each(ALL_ROLES)("returns 3 sales tabs for %s only if admin", (role) => {
+    const tabs = getTabsForRole(role, "en")
+    if (SALES_ADMIN_ROLES.includes(role)) {
+      expect(tabs).toHaveLength(3)
+      expect(tabs[0].href).toBe("/en/sales")
+      expect(tabs[1].href).toBe("/en/sales/import")
+      expect(tabs[2].href).toBe("/en/sales/analytics")
+    } else {
+      expect(tabs).toEqual([])
+    }
+  })
+
+  it("returns [] for a missing role (logged-out session)", () => {
+    expect(getTabsForRole(null, "en")).toEqual([])
+    expect(getTabsForRole(undefined, "en")).toEqual([])
+  })
+
+  it("honors the lang param for tab hrefs", () => {
+    const arTabs = getTabsForRole("ADMIN", "ar")
+    expect(arTabs[0].href).toBe("/ar/sales")
+    expect(arTabs[1].href).toBe("/ar/sales/import")
+    expect(arTabs[2].href).toBe("/ar/sales/analytics")
+  })
+
+  it("honors the dictionary param for tab names (RTL-friendly)", () => {
+    const tabs = getTabsForRole("ADMIN", "ar", {
+      navAll: "كل العملاء",
+      navImport: "استيراد",
+      navAnalytics: "تحليلات",
+    })
+    expect(tabs.map((t) => t.name)).toEqual([
+      "كل العملاء",
+      "استيراد",
+      "تحليلات",
+    ])
+  })
+})
+
+describe("sales/permissions — getUIConfigForRole", () => {
+  it.each(ALL_ROLES)(
+    "%s gets FULL_UI for admins, NO_UI for everyone else",
+    (role) => {
+      const config = getUIConfigForRole(role)
+      if (SALES_ADMIN_ROLES.includes(role)) {
+        expect(config).toEqual(FULL_UI_PERMISSIONS)
+      } else {
+        expect(config).toEqual(NO_UI_PERMISSIONS)
+      }
+    }
+  )
+
+  it("returns NO_UI for null/undefined role (logged-out)", () => {
+    expect(getUIConfigForRole(null)).toEqual(NO_UI_PERMISSIONS)
+    expect(getUIConfigForRole(undefined)).toEqual(NO_UI_PERMISSIONS)
+  })
+})

--- a/src/lib/rbac/__tests__/ui-permissions.test.ts
+++ b/src/lib/rbac/__tests__/ui-permissions.test.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { describe, expect, it } from "vitest"
+
+import { ALL_ROLES, type Role } from "../types"
+import {
+  ACADEMIC_WRITE_ROLES,
+  ADMIN_ROLES,
+  FINANCE_WRITE_ROLES,
+  FULL_UI_PERMISSIONS,
+  NO_UI_PERMISSIONS,
+  READ_ONLY_UI_PERMISSIONS,
+  STAFF_WRITE_ROLES,
+  intersectPermissions,
+  isRoleIn,
+  type UIPermissions,
+} from "../ui-permissions"
+
+// ---------------------------------------------------------------------------
+// Role × bucket matrix — one source of truth for "who's in what bucket"
+// ---------------------------------------------------------------------------
+
+const ROLE_BUCKETS = {
+  ADMIN_ROLES,
+  STAFF_WRITE_ROLES,
+  ACADEMIC_WRITE_ROLES,
+  FINANCE_WRITE_ROLES,
+} as const
+
+// Expected membership per role × bucket. Reading this table answers
+// "which roles can write what" without grepping the codebase.
+const EXPECTED_MEMBERSHIP: Record<Role, Record<keyof typeof ROLE_BUCKETS, boolean>> = {
+  DEVELOPER: {
+    ADMIN_ROLES: true,
+    STAFF_WRITE_ROLES: true,
+    ACADEMIC_WRITE_ROLES: true,
+    FINANCE_WRITE_ROLES: true,
+  },
+  ADMIN: {
+    ADMIN_ROLES: true,
+    STAFF_WRITE_ROLES: true,
+    ACADEMIC_WRITE_ROLES: true,
+    FINANCE_WRITE_ROLES: true,
+  },
+  TEACHER: {
+    ADMIN_ROLES: false,
+    STAFF_WRITE_ROLES: false,
+    ACADEMIC_WRITE_ROLES: true,
+    FINANCE_WRITE_ROLES: false,
+  },
+  STUDENT: {
+    ADMIN_ROLES: false,
+    STAFF_WRITE_ROLES: false,
+    ACADEMIC_WRITE_ROLES: false,
+    FINANCE_WRITE_ROLES: false,
+  },
+  GUARDIAN: {
+    ADMIN_ROLES: false,
+    STAFF_WRITE_ROLES: false,
+    ACADEMIC_WRITE_ROLES: false,
+    FINANCE_WRITE_ROLES: false,
+  },
+  ACCOUNTANT: {
+    ADMIN_ROLES: false,
+    STAFF_WRITE_ROLES: false,
+    ACADEMIC_WRITE_ROLES: false,
+    FINANCE_WRITE_ROLES: true,
+  },
+  STAFF: {
+    ADMIN_ROLES: false,
+    STAFF_WRITE_ROLES: true,
+    ACADEMIC_WRITE_ROLES: false,
+    FINANCE_WRITE_ROLES: false,
+  },
+  USER: {
+    ADMIN_ROLES: false,
+    STAFF_WRITE_ROLES: false,
+    ACADEMIC_WRITE_ROLES: false,
+    FINANCE_WRITE_ROLES: false,
+  },
+}
+
+// ---------------------------------------------------------------------------
+// isRoleIn — null-safety + matrix
+// ---------------------------------------------------------------------------
+
+describe("isRoleIn", () => {
+  it("returns false for null or undefined (never blow up on a missing session)", () => {
+    expect(isRoleIn(null, ADMIN_ROLES)).toBe(false)
+    expect(isRoleIn(undefined, ADMIN_ROLES)).toBe(false)
+  })
+
+  it("returns false for a string that isn't a known Role", () => {
+    expect(isRoleIn("SUPER_USER" as Role, ADMIN_ROLES)).toBe(false)
+  })
+
+  it("matches the EXPECTED_MEMBERSHIP table for every (role, bucket) pair", () => {
+    for (const role of ALL_ROLES) {
+      for (const bucketName of Object.keys(ROLE_BUCKETS) as Array<
+        keyof typeof ROLE_BUCKETS
+      >) {
+        const bucket = ROLE_BUCKETS[bucketName]
+        const expected = EXPECTED_MEMBERSHIP[role][bucketName]
+        expect(
+          isRoleIn(role, bucket),
+          `role=${role} bucket=${bucketName}`
+        ).toBe(expected)
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Canned permission constants — pin the shape so a future flag addition
+// is intentional, not accidental.
+// ---------------------------------------------------------------------------
+
+describe("permission constants", () => {
+  it("NO_UI_PERMISSIONS denies every action and marks readOnlyMode true", () => {
+    expect(NO_UI_PERMISSIONS).toEqual({
+      showAddButton: false,
+      showImportButton: false,
+      showExportButton: false,
+      showBulkActions: false,
+      showEditAction: false,
+      showDeleteAction: false,
+      showArchiveAction: false,
+      showRestoreAction: false,
+      showToggleStatus: false,
+      readOnlyMode: true,
+    })
+  })
+
+  it("FULL_UI_PERMISSIONS allows every action and clears readOnlyMode", () => {
+    expect(FULL_UI_PERMISSIONS).toEqual({
+      showAddButton: true,
+      showImportButton: true,
+      showExportButton: true,
+      showBulkActions: true,
+      showEditAction: true,
+      showDeleteAction: true,
+      showArchiveAction: true,
+      showRestoreAction: true,
+      showToggleStatus: true,
+      readOnlyMode: false,
+    })
+  })
+
+  it("READ_ONLY_UI_PERMISSIONS extends NONE with export only", () => {
+    expect(READ_ONLY_UI_PERMISSIONS).toEqual({
+      ...NO_UI_PERMISSIONS,
+      showExportButton: true,
+    })
+    expect(READ_ONLY_UI_PERMISSIONS.readOnlyMode).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// intersectPermissions — AND for flags, OR for readOnlyMode
+// ---------------------------------------------------------------------------
+
+describe("intersectPermissions", () => {
+  it("returns NO_UI_PERMISSIONS when ANDing NONE with FULL (deny wins)", () => {
+    const out = intersectPermissions(NO_UI_PERMISSIONS, FULL_UI_PERMISSIONS)
+    expect(out).toEqual(NO_UI_PERMISSIONS)
+  })
+
+  it("returns FULL_UI_PERMISSIONS when ANDing FULL with FULL", () => {
+    const out = intersectPermissions(FULL_UI_PERMISSIONS, FULL_UI_PERMISSIONS)
+    expect(out).toEqual(FULL_UI_PERMISSIONS)
+  })
+
+  it("AND-s the action flags (deny in either side denies the result)", () => {
+    const a: UIPermissions = { ...FULL_UI_PERMISSIONS, showDeleteAction: false }
+    const b: UIPermissions = { ...FULL_UI_PERMISSIONS, showImportButton: false }
+    const out = intersectPermissions(a, b)
+    expect(out.showDeleteAction).toBe(false)
+    expect(out.showImportButton).toBe(false)
+    expect(out.showAddButton).toBe(true)
+    expect(out.showEditAction).toBe(true)
+  })
+
+  it("OR-s readOnlyMode (read-only in either side makes the result read-only)", () => {
+    const writable: UIPermissions = { ...FULL_UI_PERMISSIONS, readOnlyMode: false }
+    const readonly: UIPermissions = { ...FULL_UI_PERMISSIONS, readOnlyMode: true }
+    expect(intersectPermissions(writable, readonly).readOnlyMode).toBe(true)
+    expect(intersectPermissions(readonly, writable).readOnlyMode).toBe(true)
+    expect(intersectPermissions(writable, writable).readOnlyMode).toBe(false)
+  })
+
+  it("is commutative — intersect(a,b) == intersect(b,a)", () => {
+    const a: UIPermissions = {
+      ...FULL_UI_PERMISSIONS,
+      showDeleteAction: false,
+      readOnlyMode: false,
+    }
+    const b: UIPermissions = {
+      ...NO_UI_PERMISSIONS,
+      showExportButton: true,
+      readOnlyMode: true,
+    }
+    expect(intersectPermissions(a, b)).toEqual(intersectPermissions(b, a))
+  })
+})


### PR DESCRIPTION
## Summary

Sprint Epic 07 calls for a role-matrix test ("log in as each role, screenshot what's visible"). A pure-TS equivalent runs in 8ms, covers all 8 roles × every feature flag, and acts as a regression guard before the eventual Playwright pass.

61 new test cases across 3 files, all passing — pure additive, no source-code behavior changes.

## Coverage map

**`src/lib/rbac/__tests__/ui-permissions.test.ts`** — pin the shared library:
- `isRoleIn` null-safety + role × bucket matrix (8 roles × 4 buckets = 32 cells in one driven loop)
- `intersectPermissions` semantics: AND for action flags, OR for `readOnlyMode`, commutative
- The 3 canned permission constants (`NO_UI_PERMISSIONS`, `FULL_UI_PERMISSIONS`, `READ_ONLY_UI_PERMISSIONS`)

**`sales/__tests__/permissions.test.ts`** — pin sales policy:
- Only `DEVELOPER` + `ADMIN` see the 3-tab sales pipeline + `FULL_UI_PERMISSIONS`
- Every other role gets `[]` + `NO_UI_PERMISSIONS`
- Covers `lang` propagation + dictionary override (RTL-friendly Arabic labels)

**`finance/__tests__/permissions.test.ts`** — pin finance policy:
- Writers (`DEVELOPER` / `ADMIN` / `ACCOUNTANT`) get the 13-tab root + 7-tab fees pipeline
- Viewers (`STUDENT` / `GUARDIAN` / `STAFF` / `TEACHER`) get the 2-tab "Overview + Fees" root + 1-tab "My Fees"
- `USER` gets nothing
- Asserts the 7-visible / 6-hidden tab split, the read-only `UIPermissions` shape for non-writers, and `buildFinanceSubTabs` gating

All three suites enumerate `ALL_ROLES` via `it.each` so a future role addition fails CI loudly until the policy is decided for it.

## Test plan

- [x] `vitest run` on all three files — 61/61 pass in 8ms
- [x] Each suite covers every role in `ALL_ROLES`, so removing/renaming a role breaks the suite at type-check time

## Why this is the Epic 07 pick

The sprint's explicit asks are "gate finance/settings/sales surfaces against permissions.ts" + the role-matrix test. The gates already exist (every feature has a `permissions.ts` returning role-specific tab lists + UI configs); what's missing is a guard that the gates do what they say. A pure-TS matrix test lands in one PR, runs every CI cycle, and turns "log in as STAFF and verify what's hidden" from a manual QA pass into an automatic regression check.

The Playwright role-matrix screenshot pass (the original sprint wording) belongs in a follow-up — it needs a dev server, auth state per role, and Browser MCP, all of which are out of scope for one PR.

Closes #341