### PR TITLE
feat(mobile-api): POST /api/mobile/translate (P0 store gate)

### DIFF
--- a/src/app/api/mobile/__tests__/translate.test.ts
+++ b/src/app/api/mobile/__tests__/translate.test.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { NextRequest } from "next/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "@/lib/db"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    announcement: { findFirst: vi.fn() },
+    assignment: { findFirst: vi.fn() },
+    translationCache: { findUnique: vi.fn() },
+  },
+}))
+
+vi.mock("@/components/translation/actions", () => ({
+  translateWithCache: vi.fn(),
+}))
+
+vi.mock("../lib/authenticate", () => ({
+  authenticate: vi.fn(),
+  isAuthError: (r: unknown) =>
+    typeof r === "object" &&
+    r !== null &&
+    "status" in r &&
+    typeof (r as { status: unknown }).status === "number",
+}))
+
+const SCHOOL_ID = "school-1"
+const USER_ID = "user-1"
+
+function buildRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/mobile/translate", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { Authorization: "Bearer test" },
+  })
+}
+
+async function authOk() {
+  const auth = await import("../lib/authenticate")
+  vi.mocked(auth.authenticate).mockResolvedValue({
+    userId: USER_ID,
+    email: "u@example.com",
+    schoolId: SCHOOL_ID,
+    role: "STUDENT",
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/mobile/translate (issue #276)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await authOk()
+  })
+
+  it("returns 400 when entity_type is not in the whitelist", async () => {
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "secret_table",
+      entity_id: "x",
+      target_lang: "en",
+    }))
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as { error: string }
+    expect(json.error).toContain("Invalid")
+  })
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/mobile/translate", {
+      method: "POST",
+      body: "{not json",
+      headers: {
+        Authorization: "Bearer test",
+        "Content-Type": "application/json",
+      },
+    })
+    const { POST } = await import("../translate/route")
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 when the announcement is not in this school (tenant guard)", async () => {
+    vi.mocked(db.announcement.findFirst).mockResolvedValue(null)
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "announcement",
+      entity_id: "ann-1",
+      target_lang: "en",
+    }))
+    expect(res.status).toBe(404)
+    // Verify the lookup was scoped by schoolId from the auth context (no
+    // way to fetch an entity from a different tenant via this endpoint).
+    expect(db.announcement.findFirst).toHaveBeenCalledWith({
+      where: { id: "ann-1", schoolId: SCHOOL_ID },
+      select: { title: true, body: true, lang: true },
+    })
+  })
+
+  it("returns the source text unchanged when source_lang === target_lang (and reports cached=true)", async () => {
+    vi.mocked(db.announcement.findFirst).mockResolvedValue({
+      title: "Hello",
+      body: "World",
+      lang: "en",
+    } as never)
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "announcement",
+      entity_id: "ann-1",
+      target_lang: "en",
+    }))
+    const json = (await res.json()) as {
+      translated_text: string
+      cached: boolean
+      source_lang: string
+    }
+    expect(res.status).toBe(200)
+    expect(json.translated_text).toBe("Hello\n\nWorld")
+    expect(json.cached).toBe(true)
+    expect(json.source_lang).toBe("en")
+    // No translation call should fire — same-language is a free path.
+    const translation = await import("@/components/translation/actions")
+    expect(translation.translateWithCache).not.toHaveBeenCalled()
+  })
+
+  it("returns cached=true when the translation already exists in TranslationCache", async () => {
+    vi.mocked(db.announcement.findFirst).mockResolvedValue({
+      title: "مرحبا",
+      body: "أهلاً",
+      lang: "ar",
+    } as never)
+    vi.mocked(db.translationCache.findUnique).mockResolvedValue({
+      id: "cache-1",
+    } as never)
+    const translation = await import("@/components/translation/actions")
+    vi.mocked(translation.translateWithCache).mockResolvedValue(
+      "Hello\n\nWelcome"
+    )
+
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "announcement",
+      entity_id: "ann-1",
+      target_lang: "en",
+    }))
+    const json = (await res.json()) as {
+      translated_text: string
+      cached: boolean
+      source_lang: string
+    }
+    expect(res.status).toBe(200)
+    expect(json.translated_text).toBe("Hello\n\nWelcome")
+    expect(json.cached).toBe(true)
+    expect(json.source_lang).toBe("ar")
+  })
+
+  it("returns cached=false on a fresh translation (no prior cache row)", async () => {
+    vi.mocked(db.announcement.findFirst).mockResolvedValue({
+      title: "مرحبا",
+      body: "أهلاً",
+      lang: "ar",
+    } as never)
+    vi.mocked(db.translationCache.findUnique).mockResolvedValue(null)
+    const translation = await import("@/components/translation/actions")
+    vi.mocked(translation.translateWithCache).mockResolvedValue("Hello")
+
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "announcement",
+      entity_id: "ann-1",
+      target_lang: "en",
+    }))
+    const json = (await res.json()) as { cached: boolean }
+    expect(res.status).toBe(200)
+    expect(json.cached).toBe(false)
+  })
+
+  it("handles assignment entities the same way", async () => {
+    vi.mocked(db.assignment.findFirst).mockResolvedValue({
+      title: "Homework",
+      description: "Chapter 3",
+      lang: "en",
+    } as never)
+    vi.mocked(db.translationCache.findUnique).mockResolvedValue(null)
+    const translation = await import("@/components/translation/actions")
+    vi.mocked(translation.translateWithCache).mockResolvedValue(
+      "واجب\n\nالفصل 3"
+    )
+
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "assignment",
+      entity_id: "asg-1",
+      target_lang: "ar",
+    }))
+    const json = (await res.json()) as {
+      translated_text: string
+      source_lang: string
+    }
+    expect(res.status).toBe(200)
+    expect(json.source_lang).toBe("en")
+    expect(json.translated_text).toBe("واجب\n\nالفصل 3")
+    expect(db.assignment.findFirst).toHaveBeenCalledWith({
+      where: { id: "asg-1", schoolId: SCHOOL_ID },
+      select: { title: true, description: true, lang: true },
+    })
+  })
+
+  it("returns 200 with empty text when the entity has empty title and body (cacheable on the client)", async () => {
+    vi.mocked(db.announcement.findFirst).mockResolvedValue({
+      title: null,
+      body: null,
+      lang: "en",
+    } as never)
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "announcement",
+      entity_id: "ann-1",
+      target_lang: "ar",
+    }))
+    const json = (await res.json()) as {
+      translated_text: string
+      cached: boolean
+    }
+    expect(res.status).toBe(200)
+    expect(json.translated_text).toBe("")
+    expect(json.cached).toBe(true)
+  })
+
+  it("returns 401 when auth fails (delegates to authenticate)", async () => {
+    const auth = await import("../lib/authenticate")
+    vi.mocked(auth.authenticate).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }) as never
+    )
+    const { POST } = await import("../translate/route")
+    const res = await POST(buildRequest({
+      entity_type: "announcement",
+      entity_id: "ann-1",
+      target_lang: "en",
+    }))
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/app/api/mobile/translate/route.ts
+++ b/src/app/api/mobile/translate/route.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+/**
+ * POST /api/mobile/translate
+ *
+ * Per-entity on-demand translation for iOS / Android. Surfaces the
+ * existing TranslationCache so mobile clients can display
+ * announcements/assignments in the user's app language without each
+ * client baking its own translation pipeline.
+ *
+ * Contract (issue #276):
+ *   Request:  { entity_type, entity_id, target_lang }
+ *   200:      { translated_text, cached, source_lang }
+ *   400/401/403/404/501 on the usual paths.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { db } from "@/lib/db"
+import { translateWithCache } from "@/components/translation/actions"
+
+import { authenticate, isAuthError } from "../lib/authenticate"
+
+const requestSchema = z.object({
+  entity_type: z.enum(["announcement", "assignment"]),
+  entity_id: z.string().min(1),
+  target_lang: z.enum(["ar", "en"]),
+})
+
+interface EntitySnapshot {
+  text: string
+  source_lang: "ar" | "en"
+}
+
+/**
+ * Pull the canonical translatable text + source language for a supported
+ * entity. Returns null when the entity doesn't exist in this school
+ * (tenant-isolated by schoolId).
+ *
+ * Whitelist-only — adding a new entity type means adding a case here AND
+ * a route test, never trusting an arbitrary client-supplied table name.
+ */
+async function loadEntity(
+  entityType: "announcement" | "assignment",
+  entityId: string,
+  schoolId: string
+): Promise<EntitySnapshot | null> {
+  switch (entityType) {
+    case "announcement": {
+      const row = await db.announcement.findFirst({
+        where: { id: entityId, schoolId },
+        select: { title: true, body: true, lang: true },
+      })
+      if (!row) return null
+      // Announcement title and body are both translatable. We join them with
+      // a delimiter the iOS client can split — keeps the round-trip to one
+      // cache entry per (title, body) pair.
+      const text = [row.title ?? "", row.body ?? ""].join("\n\n").trim()
+      return { text, source_lang: row.lang as "ar" | "en" }
+    }
+    case "assignment": {
+      const row = await db.assignment.findFirst({
+        where: { id: entityId, schoolId },
+        select: { title: true, description: true, lang: true },
+      })
+      if (!row) return null
+      const text = [row.title, row.description ?? ""].join("\n\n").trim()
+      return { text, source_lang: row.lang as "ar" | "en" }
+    }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticate(request)
+    if (isAuthError(auth)) return auth
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json(
+        { error: "Body must be valid JSON" },
+        { status: 400 }
+      )
+    }
+
+    const parsed = requestSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request",
+          details: parsed.error.flatten().fieldErrors,
+        },
+        { status: 400 }
+      )
+    }
+    const { entity_type, entity_id, target_lang } = parsed.data
+
+    const snapshot = await loadEntity(entity_type, entity_id, auth.schoolId)
+    if (!snapshot) {
+      return NextResponse.json({ error: "Entity not found" }, { status: 404 })
+    }
+    if (!snapshot.text) {
+      // Empty source text — nothing to translate, but still a 200 so the
+      // client can cache the empty result without a special error path.
+      return NextResponse.json({
+        translated_text: "",
+        cached: true,
+        source_lang: snapshot.source_lang,
+      })
+    }
+
+    // No-op when source equals target. Return cached=true so the client
+    // knows it's free to memoize the response.
+    if (snapshot.source_lang === target_lang) {
+      return NextResponse.json({
+        translated_text: snapshot.text,
+        cached: true,
+        source_lang: snapshot.source_lang,
+      })
+    }
+
+    // Probe the cache directly so the response can honestly report whether
+    // this was a hit or a fresh Google Translate call. translateWithCache
+    // does the same lookup internally; the extra read costs ~1ms and the
+    // honest signal helps the iOS analytics distinguish hit-rate decay
+    // from real translation latency.
+    const cacheHit = await db.translationCache.findUnique({
+      where: {
+        schoolId_sourceText_sourceLanguage_targetLanguage: {
+          schoolId: auth.schoolId,
+          sourceText: snapshot.text,
+          sourceLanguage: snapshot.source_lang,
+          targetLanguage: target_lang,
+        },
+      },
+      select: { id: true },
+    })
+
+    const translated_text = await translateWithCache(
+      snapshot.text,
+      snapshot.source_lang,
+      target_lang,
+      auth.schoolId
+    )
+
+    return NextResponse.json({
+      translated_text,
+      cached: Boolean(cacheHit),
+      source_lang: snapshot.source_lang,
+    })
+  } catch (error) {
+    console.error("Mobile translate error:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary

First of the Epic 09 P0 mobile-API store-gate endpoints. Surfaces the existing `TranslationCache` + `getDisplayText` pipeline to iOS / Android clients so they can render announcements + assignments in the user's app language without baking a translation pipeline into each client.

## Contract (from #276)

```
POST /api/mobile/translate
Authorization: Bearer <jwt>

Request:  { entity_type: "announcement" | "assignment", entity_id: string, target_lang: "ar" | "en" }
Response: { translated_text: string, cached: boolean, source_lang: "ar" | "en" }
```

## Scope decisions worth reviewing

- **Whitelist entity types** — only `announcement` + `assignment` for v1. `message` is intentionally excluded: the `Message` model lacks a `lang` field and adding it is a separate schema migration. A `default` case isn't possible because Zod rejects unknown types at the validation step.
- **Tenant isolation via JWT schoolId** — the auth header is the only way to scope the lookup. An attacker can't reach across tenants by guessing `entity_id`. The test explicitly asserts the `schoolId` is on every `findFirst` call so a future refactor can't silently drop it.
- **Honest `cached: boolean`** — direct `TranslationCache.findUnique` lookup before calling `translateWithCache` (which does the same internal lookup). Costs ~1ms; lets iOS analytics distinguish hit-rate decay from real translation latency. Worth it.
- **Same-language shortcut** — returns source with `cached: true` so the client can memoize without a special branch.
- **Empty source returns 200** — `translated_text: ""`, `cached: true`. Lets the iOS draft-announcement case cache cleanly without an error path.

## Test plan

- [x] `vitest run src/app/api/mobile/__tests__/translate.test.ts` — 9/9 pass in 36ms
- [x] Tests cover: whitelist rejection (400), malformed JSON (400), tenant-isolated 404, same-lang shortcut, cache hit, cache miss, assignment path, empty source, auth-fail 401

## Follow-ups (separate issues)

- Add `lang` field to the `Message` model so messages can be translated through this endpoint
- Wire iOS client to call this endpoint (LOC-010)
- Other P0 endpoints (#274 export, #275 delete, #277 payments, #278 invoices, #279 consent) ship as separate PRs

Refs #276
Refs #315
Closes #345