### PR TITLE
feat(catalog): coverage helper for browse + admin reporting

### DIFF
--- a/src/lib/catalog/__tests__/coverage.test.ts
+++ b/src/lib/catalog/__tests__/coverage.test.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "@/lib/db"
+
+import {
+  getCurriculumCoverage,
+  listCurriculaWithCoverage,
+} from "../coverage"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    curriculum: { findUnique: vi.fn(), findMany: vi.fn() },
+    subject: { findMany: vi.fn() },
+    chapter: { findMany: vi.fn() },
+  },
+}))
+
+const SD_CURRICULUM = {
+  id: "cur-sd",
+  name: "Sudan National Curriculum",
+  slug: "sd-national",
+  country: "SD",
+  code: "national",
+}
+
+const SA_CURRICULUM = {
+  id: "cur-sa",
+  name: "Saudi (Tatweer)",
+  slug: "sa-tatweer",
+  country: "SA",
+  code: "tatweer",
+}
+
+// ---------------------------------------------------------------------------
+// getCurriculumCoverage
+// ---------------------------------------------------------------------------
+
+describe("getCurriculumCoverage", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns null when the curriculum id is unknown (caller treats as 'not seeded yet')", async () => {
+    vi.mocked(db.curriculum.findUnique).mockResolvedValue(null)
+    const out = await getCurriculumCoverage("missing")
+    expect(out).toBe(null)
+    // Critical: no subject/chapter lookups when curriculum doesn't exist
+    expect(db.subject.findMany).not.toHaveBeenCalled()
+    expect(db.chapter.findMany).not.toHaveBeenCalled()
+  })
+
+  it("returns an empty coverage report when the curriculum has zero subjects", async () => {
+    vi.mocked(db.curriculum.findUnique).mockResolvedValue(SA_CURRICULUM as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([] as never)
+
+    const out = await getCurriculumCoverage(SA_CURRICULUM.id)
+    expect(out).not.toBe(null)
+    expect(out!.curriculum.country).toBe("SA")
+    expect(out!.subjects.total).toBe(0)
+    expect(out!.subjects.byGrade).toEqual({})
+    expect(out!.subjects.byDepartment).toEqual({})
+    expect(out!.chapters.total).toBe(0)
+    expect(out!.lessons.total).toBe(0)
+    // Empty subject set should skip the chapter lookup entirely.
+    expect(db.chapter.findMany).not.toHaveBeenCalled()
+  })
+
+  it("aggregates grade + department distributions across subjects", async () => {
+    vi.mocked(db.curriculum.findUnique).mockResolvedValue(SD_CURRICULUM as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([
+      {
+        id: "s1",
+        grades: [1, 2, 3],
+        department: "العلوم",
+        totalChapters: 5,
+        totalLessons: 30,
+      },
+      {
+        id: "s2",
+        grades: [1],
+        department: "العلوم",
+        totalChapters: 2,
+        totalLessons: 8,
+      },
+      {
+        id: "s3",
+        grades: [4, 5],
+        department: "اللغات",
+        totalChapters: 0,
+        totalLessons: 0,
+      },
+    ] as never)
+    vi.mocked(db.chapter.findMany).mockResolvedValue([
+      { id: "ch1", _count: { lessons: 10 } },
+      { id: "ch2", _count: { lessons: 0 } },
+      { id: "ch3", _count: { lessons: 5 } },
+    ] as never)
+
+    const out = (await getCurriculumCoverage(SD_CURRICULUM.id))!
+    expect(out.subjects.total).toBe(3)
+    expect(out.subjects.byGrade).toEqual({ 1: 2, 2: 1, 3: 1, 4: 1, 5: 1 })
+    expect(out.subjects.byDepartment).toEqual({ العلوم: 2, اللغات: 1 })
+    expect(out.subjects.withChapters).toBe(2) // s1 and s2
+    expect(out.subjects.withoutChapters).toBe(1) // s3
+    expect(out.lessons.total).toBe(38)
+    expect(out.chapters.withLessons).toBe(2)
+    expect(out.chapters.withoutLessons).toBe(1)
+  })
+
+  it("uses the joined chapter count when the denormalized total is stale (no chapters but rows exist)", async () => {
+    vi.mocked(db.curriculum.findUnique).mockResolvedValue(SD_CURRICULUM as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([
+      {
+        id: "s1",
+        grades: [1],
+        department: "Math",
+        totalChapters: 0, // stale denormalized field
+        totalLessons: 0,
+      },
+    ] as never)
+    vi.mocked(db.chapter.findMany).mockResolvedValue([
+      { id: "ch1", _count: { lessons: 3 } },
+    ] as never)
+
+    const out = (await getCurriculumCoverage(SD_CURRICULUM.id))!
+    expect(out.chapters.total).toBe(1) // falls back to chapters.length when denorm is 0
+    expect(out.chapters.withLessons).toBe(1)
+  })
+
+  it("scopes the chapter lookup to the curriculum's subject ids only", async () => {
+    vi.mocked(db.curriculum.findUnique).mockResolvedValue(SD_CURRICULUM as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([
+      { id: "s1", grades: [1], department: "x", totalChapters: 1, totalLessons: 2 },
+      { id: "s2", grades: [2], department: "x", totalChapters: 1, totalLessons: 2 },
+    ] as never)
+    vi.mocked(db.chapter.findMany).mockResolvedValue([] as never)
+
+    await getCurriculumCoverage(SD_CURRICULUM.id)
+    expect(db.chapter.findMany).toHaveBeenCalledWith({
+      where: { subjectId: { in: ["s1", "s2"] } },
+      select: { id: true, _count: { select: { lessons: true } } },
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listCurriculaWithCoverage
+// ---------------------------------------------------------------------------
+
+describe("listCurriculaWithCoverage", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns [] when no curricula are seeded yet (skips the subject lookup)", async () => {
+    vi.mocked(db.curriculum.findMany).mockResolvedValue([] as never)
+    const out = await listCurriculaWithCoverage()
+    expect(out).toEqual([])
+    expect(db.subject.findMany).not.toHaveBeenCalled()
+  })
+
+  it("returns one row per curriculum with subjectCount + sorted unique grades", async () => {
+    vi.mocked(db.curriculum.findMany).mockResolvedValue([
+      SD_CURRICULUM,
+      SA_CURRICULUM,
+    ] as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([
+      { curriculumId: "cur-sd", grades: [1, 2] },
+      { curriculumId: "cur-sd", grades: [2, 3] },
+      { curriculumId: "cur-sa", grades: [7, 9, 8] }, // intentionally out-of-order
+    ] as never)
+
+    const out = await listCurriculaWithCoverage()
+    expect(out).toHaveLength(2)
+    const sd = out.find((c) => c.id === "cur-sd")!
+    const sa = out.find((c) => c.id === "cur-sa")!
+    expect(sd.subjectCount).toBe(2)
+    expect(sd.gradeCoverage).toEqual([1, 2, 3]) // unique + sorted ascending
+    expect(sa.subjectCount).toBe(1)
+    expect(sa.gradeCoverage).toEqual([7, 8, 9])
+  })
+
+  it("returns a row with zero subjects when the curriculum exists but has no Subject rows yet", async () => {
+    vi.mocked(db.curriculum.findMany).mockResolvedValue([SA_CURRICULUM] as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([] as never)
+
+    const out = await listCurriculaWithCoverage()
+    expect(out).toHaveLength(1)
+    expect(out[0]).toEqual({
+      id: SA_CURRICULUM.id,
+      name: SA_CURRICULUM.name,
+      slug: SA_CURRICULUM.slug,
+      country: SA_CURRICULUM.country,
+      subjectCount: 0,
+      gradeCoverage: [],
+    })
+  })
+
+  it("ignores subjects with no curriculumId (orphan rows from pre-Phase-4 data)", async () => {
+    vi.mocked(db.curriculum.findMany).mockResolvedValue([SD_CURRICULUM] as never)
+    vi.mocked(db.subject.findMany).mockResolvedValue([
+      { curriculumId: "cur-sd", grades: [1] },
+      { curriculumId: null, grades: [2] }, // legacy row not yet backfilled
+    ] as never)
+    const out = await listCurriculaWithCoverage()
+    expect(out[0].subjectCount).toBe(1)
+    expect(out[0].gradeCoverage).toEqual([1])
+  })
+})

--- a/src/lib/catalog/coverage.ts
+++ b/src/lib/catalog/coverage.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2025-present databayt
+// Licensed under SSPL-1.0 -- see LICENSE for details
+
+/**
+ * Catalog coverage helpers.
+ *
+ * Reads the existing Curriculum / Subject / Chapter / Lesson schema and
+ * reports what's populated per curriculum. Powers the eventual catalog
+ * browse + bridge UI (sprint Epic 15) and surfaces a quick "what's
+ * actually seeded" answer for any admin or CI smoke test.
+ *
+ * Pure reads — no auth, no React, no side effects.
+ */
+
+import { db } from "@/lib/db"
+
+export interface CurriculumCoverage {
+  curriculum: {
+    id: string
+    name: string
+    slug: string
+    country: string
+    code: string
+  }
+  subjects: {
+    total: number
+    /** Distribution of subjects covering each grade index (1..12). */
+    byGrade: Record<number, number>
+    /** Distribution by `department` (e.g. "العلوم", "Mathematics"). */
+    byDepartment: Record<string, number>
+    withChapters: number
+    withoutChapters: number
+  }
+  chapters: {
+    total: number
+    withLessons: number
+    withoutLessons: number
+  }
+  lessons: {
+    total: number
+  }
+}
+
+export interface CurriculumSummary {
+  id: string
+  name: string
+  slug: string
+  country: string
+  subjectCount: number
+  /** Sorted unique grade indices covered by at least one subject. */
+  gradeCoverage: number[]
+}
+
+/**
+ * Detailed coverage for a single curriculum. Returns null when no
+ * curriculum row matches the given id — callers should treat that as
+ * "unknown curriculum" rather than throwing.
+ */
+export async function getCurriculumCoverage(
+  curriculumId: string
+): Promise<CurriculumCoverage | null> {
+  const curriculum = await db.curriculum.findUnique({
+    where: { id: curriculumId },
+    select: { id: true, name: true, slug: true, country: true, code: true },
+  })
+  if (!curriculum) return null
+
+  // Pull every subject in this curriculum with just the fields needed to
+  // compute the distributions. The bridge models (SubjectSelection) are
+  // not consulted here — coverage is about what content exists, not
+  // what schools have adopted.
+  const subjects = await db.subject.findMany({
+    where: { curriculumId },
+    select: {
+      id: true,
+      grades: true,
+      department: true,
+      totalChapters: true,
+      totalLessons: true,
+    },
+  })
+
+  const byGrade: Record<number, number> = {}
+  const byDepartment: Record<string, number> = {}
+  let withChapters = 0
+  let withoutChapters = 0
+  let chapterTotal = 0
+  let lessonTotal = 0
+
+  for (const subj of subjects) {
+    for (const grade of subj.grades ?? []) {
+      byGrade[grade] = (byGrade[grade] ?? 0) + 1
+    }
+    byDepartment[subj.department] = (byDepartment[subj.department] ?? 0) + 1
+    if ((subj.totalChapters ?? 0) > 0) {
+      withChapters += 1
+      chapterTotal += subj.totalChapters
+    } else {
+      withoutChapters += 1
+    }
+    lessonTotal += subj.totalLessons ?? 0
+  }
+
+  // For the chapter-level coverage we need an actual chapter join. The
+  // denormalized totalChapters on Subject doesn't say "how many of the
+  // chapters have any lessons attached", which is the UI's typical
+  // empty-state question.
+  const subjectIds = subjects.map((s) => s.id)
+  const chapters = subjectIds.length
+    ? await db.chapter.findMany({
+        where: { subjectId: { in: subjectIds } },
+        select: { id: true, _count: { select: { lessons: true } } },
+      })
+    : []
+
+  let chaptersWithLessons = 0
+  let chaptersWithoutLessons = 0
+  for (const ch of chapters) {
+    if (ch._count.lessons > 0) chaptersWithLessons += 1
+    else chaptersWithoutLessons += 1
+  }
+
+  return {
+    curriculum,
+    subjects: {
+      total: subjects.length,
+      byGrade,
+      byDepartment,
+      withChapters,
+      withoutChapters,
+    },
+    chapters: {
+      total: chapterTotal || chapters.length,
+      withLessons: chaptersWithLessons,
+      withoutLessons: chaptersWithoutLessons,
+    },
+    lessons: { total: lessonTotal },
+  }
+}
+
+/**
+ * Lightweight listing for the catalog browse landing — every curriculum
+ * with its subject count and the sorted set of grade indices it covers.
+ * One query each for curricula + subjects so the cost is O(2) regardless
+ * of how many curricula are seeded.
+ */
+export async function listCurriculaWithCoverage(): Promise<CurriculumSummary[]> {
+  const curricula = await db.curriculum.findMany({
+    select: { id: true, name: true, slug: true, country: true },
+    orderBy: { name: "asc" },
+  })
+
+  if (curricula.length === 0) return []
+
+  const subjects = await db.subject.findMany({
+    where: { curriculumId: { in: curricula.map((c) => c.id) } },
+    select: { curriculumId: true, grades: true },
+  })
+
+  const byCurriculum = new Map<
+    string,
+    { subjectCount: number; grades: Set<number> }
+  >()
+  for (const c of curricula) {
+    byCurriculum.set(c.id, { subjectCount: 0, grades: new Set() })
+  }
+  for (const s of subjects) {
+    if (!s.curriculumId) continue
+    const bucket = byCurriculum.get(s.curriculumId)
+    if (!bucket) continue
+    bucket.subjectCount += 1
+    for (const g of s.grades ?? []) bucket.grades.add(g)
+  }
+
+  return curricula.map((c) => {
+    const bucket = byCurriculum.get(c.id)!
+    return {
+      id: c.id,
+      name: c.name,
+      slug: c.slug,
+      country: c.country,
+      subjectCount: bucket.subjectCount,
+      gradeCoverage: [...bucket.grades].sort((a, b) => a - b),
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Sprint Epic 15 (Global Catalog) lists the catalog browse UI + curricula seeds. The schema is fully built and Sudan + US are seeded — but nothing surfaces "what's actually populated per curriculum" in one query.

This adds two pure helpers. The eventual `/admin/catalog/bridge` UI can render a coverage summary in one call, and any admin or CI smoke test can answer "how complete is each curriculum?" in milliseconds.

## Changes

- **`src/lib/catalog/coverage.ts`** — two pure functions:
  - `getCurriculumCoverage(id)` — detailed report: curriculum metadata, `subjects { total, byGrade, byDepartment, withChapters, withoutChapters }`, `chapters { total, withLessons, withoutLessons }`, `lessons { total }`. Returns `null` for an unknown id (caller treats as "not seeded yet").
  - `listCurriculaWithCoverage()` — landing-page summary: every curriculum with `subjectCount` + sorted unique grade indices. Two queries total regardless of how many curricula are seeded.
- **`src/lib/catalog/__tests__/coverage.test.ts`** — 9 tests covering the empty / partial / full / stale-denorm / orphan-row paths.

## Why a helper instead of a Saudi/IGCSE seed

A real curriculum seed needs real subject names, chapter spines, and per-grade lesson lists. Making them up with placeholder data risks shipping wrong content that bridge tables across pilot schools would cache. The helper:
- Ships with confidence today (pure reads, fully tested)
- Unblocks the bridge UI without waiting for authoritative curriculum data
- Makes the next seed PR observable — "after `sa-catalog.ts` ships, `getCurriculumCoverage('sa-tatweer')` should report 6 subjects across grades 1-12"

## Test plan

- [x] `vitest run src/lib/catalog/__tests__/coverage.test.ts` — 9/9 pass in 4ms
- [x] Coverage paths: null on unknown id (no downstream lookups), empty curriculum returns empty distributions, multi-subject aggregation with grade + department buckets, denormalized-stale fallback, scoped chapter query, list with sort + dedup, list with zero-subject row, list ignoring legacy null-curriculumId rows

## Follow-ups (separate issues)

- `/admin/catalog/bridge` UI consuming both helpers
- Saudi (Tatweer) curriculum seed once the subject/chapter spine is sourced
- IGCSE / IB skeleton
- First mock-exam pack (Arabic — math/Arabic/science, grades 6-9)

Closes #347
Refs Epic 15